### PR TITLE
Datastore controller will retry single file queries

### DIFF
--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -31,64 +31,70 @@
 
 (defn view
   []
-  (let [{:keys [ds/current ds/download-pending?] :as ds} (data/get-in-app-state :app/datastore)
+  (let [{:keys [ds/current ds/download-pending? ds/error] :as ds}
+        (data/get-in-app-state :app/datastore)
         activities->string (:ds/activities ds)
         md (data/get-in-app-state :app/datastore :ds/file-metadata current)]
-    (if-not md
-      [:div.loading
-       (icons/loading :large)]
-      (let [{:keys [kixi.datastore.metadatastore/file-type
-                    kixi.datastore.metadatastore/name
-                    kixi.datastore.metadatastore/sharing
-                    kixi.datastore.metadatastore/provenance
-                    kixi.datastore.metadatastore/size-bytes]} md
-            sharing-groups (set (reduce concat [] (vals sharing)))]
-        [:div#data-view.padded-content
-         [:h2 (get-string :string/file-name ":" name)]
-         ;; ----------------------------------------------
-         [:hr]
-         [:div.field-entries
-          [:div.field-entry
-           [:strong (get-string :string/file-type ":")]
-           [:span file-type]]
-          [:div.field-entry
-           [:strong (get-string :string/file-provenance-source ":")]
-           [:span (:kixi.datastore.metadatastore/source provenance)]]
-          [:div.field-entry
-           [:strong (get-string :string/created-at ":")]
-           [:span (utils/iso-time-as-moment (:kixi.datastore.metadatastore/created provenance))]]
-          [:div.field-entry
-           [:strong (get-string :string/file-size ":")]
-           [:span (js/filesize size-bytes)]]
-          [:div.field-entry
-           [:strong (get-string :string/file-uploader ":")]
-           [:span (get-in provenance [:kixi/user :kixi.user/name])]]]
-         ;; ----------------------------------------------
-         [:hr]
-         [:div.sharing-controls
-          [:h2 (get-string :string/sharing)]
-          [:div.sharing-activity
-           [:div.selected-groups
-            [shared/sharing-matrix activities->string
-             (reverse-group->activity-map (keys activities->string) sharing)
-             {:on-change
-              (fn [[group activities] activity target-state]
-                (controller/raise! :data/sharing-change
-                                   {:current current
-                                    :group group
-                                    :activity activity
-                                    :target-state target-state}))
-              :on-add
-              (fn [group]
-                (controller/raise! :data/sharing-add-group
-                                   {:current current :group group}))}
-             {:exclusions sharing-groups}]]]]
-         ;; ----------------------------------------------
-         [:hr]
-         [:div.actions
-          (shared/button {:id :button-a
-                          :icon (if download-pending? icons/loading icons/download)
-                          :txt :string/file-actions-download-file
-                          :class "file-action-download"}
-                         #(when-not download-pending?
-                            (controller/raise! :data/download-file {:id current})))]]))))
+    (if error
+      [:div.text-center.padded-content
+       [:div
+        (icons/error :dark :large)]
+       [:div [:h3 (get-string error)]]]
+      (if-not md
+        [:div.loading
+         (icons/loading :large)]
+        (let [{:keys [kixi.datastore.metadatastore/file-type
+                      kixi.datastore.metadatastore/name
+                      kixi.datastore.metadatastore/sharing
+                      kixi.datastore.metadatastore/provenance
+                      kixi.datastore.metadatastore/size-bytes]} md
+              sharing-groups (set (reduce concat [] (vals sharing)))]
+          [:div#data-view.padded-content
+           [:h2 (get-string :string/file-name ":" name)]
+           ;; ----------------------------------------------
+           [:hr]
+           [:div.field-entries
+            [:div.field-entry
+             [:strong (get-string :string/file-type ":")]
+             [:span file-type]]
+            [:div.field-entry
+             [:strong (get-string :string/file-provenance-source ":")]
+             [:span (:kixi.datastore.metadatastore/source provenance)]]
+            [:div.field-entry
+             [:strong (get-string :string/created-at ":")]
+             [:span (utils/iso-time-as-moment (:kixi.datastore.metadatastore/created provenance))]]
+            [:div.field-entry
+             [:strong (get-string :string/file-size ":")]
+             [:span (js/filesize size-bytes)]]
+            [:div.field-entry
+             [:strong (get-string :string/file-uploader ":")]
+             [:span (get-in provenance [:kixi/user :kixi.user/name])]]]
+           ;; ----------------------------------------------
+           [:hr]
+           [:div.sharing-controls
+            [:h2 (get-string :string/sharing)]
+            [:div.sharing-activity
+             [:div.selected-groups
+              [shared/sharing-matrix activities->string
+               (reverse-group->activity-map (keys activities->string) sharing)
+               {:on-change
+                (fn [[group activities] activity target-state]
+                  (controller/raise! :data/sharing-change
+                                     {:current current
+                                      :group group
+                                      :activity activity
+                                      :target-state target-state}))
+                :on-add
+                (fn [group]
+                  (controller/raise! :data/sharing-add-group
+                                     {:current current :group group}))}
+               {:exclusions sharing-groups}]]]]
+           ;; ----------------------------------------------
+           [:hr]
+           [:div.actions
+            (shared/button {:id :button-a
+                            :icon (if download-pending? icons/loading icons/download)
+                            :txt :string/file-actions-download-file
+                            :class "file-action-download"}
+                           #(when-not download-pending?
+                              (controller/raise! :data/download-file {:id current})))]])))))

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -123,17 +123,16 @@
   :datastore/metadata-by-id
   [[_ data]]
   (if (:error data)
-    (do
-      (let [id (first (get-in data [:original :params]))
-            tries (data/get-in-app-state :app/datastore :ds/query-tries)]
-        (if (< tries 3)
-          (do
-            (data/swap-app-state! :app/datastore update :ds/query-tries inc)
-            (send-single-file-item-query! id))
-          (do
-            (log/warn "File" id "is not accessible.")
-            (data/swap-app-state! :app/datastore assoc :ds/error :string/file-inaccessible)
-            (data/swap-app-state! :app/datastore assoc :ds/query-tries 0)))))
+    (let [id (first (get-in data [:original :params]))
+          tries (data/get-in-app-state :app/datastore :ds/query-tries)]
+      (if (< tries 3)
+        (do
+          (data/swap-app-state! :app/datastore update :ds/query-tries inc)
+          (send-single-file-item-query! id))
+        (do
+          (log/warn "File" id "is not accessible.")
+          (data/swap-app-state! :app/datastore assoc :ds/error :string/file-inaccessible)
+          (data/swap-app-state! :app/datastore assoc :ds/query-tries 0))))
     (do
       (data/swap-app-state! :app/datastore assoc :ds/query-tries 0)
       (save-file-metadata! data)

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -32,6 +32,8 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(declare on-query-response)
+
 (defn select-current!
   [id]
   (when id
@@ -48,6 +50,20 @@
                  (vec (keep (fn [[group group-activities]]
                               (when (get group-activities activity)
                                 (:kixi.group/id group))) groups))) activities)))
+
+(defn send-dashboard-query!
+  [id]
+  (when-not @dash-query-pending?
+    (reset! dash-query-pending? true)
+    (data/query {:datastore/metadata-with-activities [[[:kixi.datastore.metadatastore/meta-read]]
+                                                      (:full query-fields)]}
+                on-query-response)))
+
+(defn send-single-file-item-query!
+  [id]
+  (data/query {:datastore/metadata-by-id
+               [[id] (:full query-fields)]}
+              on-query-response))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; API responses
@@ -98,7 +114,6 @@
   :datastore/metadata-with-activities
   [[_ data]]
   (reset! dash-query-pending? false)
-  (log/debug ">>>>> GOT RESULTS" data)
   (data/swap-app-state! :app/data-dash assoc
                         :items (get data :items)
                         :paging (get data :paging)))
@@ -107,33 +122,31 @@
 (defmethod on-query-response
   :datastore/metadata-by-id
   [[_ data]]
-  (log/debug ">>>>> GOT RESULTS BY ID" data)
-  (when-not (:error data)
-    (save-file-metadata! data)
-    (set-title! "File -" (:kixi.datastore.metadatastore/name data))))
+  (if (:error data)
+    (do
+      (let [id (first (get-in data [:original :params]))
+            tries (data/get-in-app-state :app/datastore :ds/query-tries)]
+        (if (< tries 3)
+          (do
+            (data/swap-app-state! :app/datastore update :ds/query-tries inc)
+            (send-single-file-item-query! id))
+          (do
+            (log/warn "File" id "is not accessible.")
+            (data/swap-app-state! :app/datastore assoc :ds/error :string/file-inaccessible)
+            (data/swap-app-state! :app/datastore assoc :ds/query-tries 0)))))
+    (do
+      (data/swap-app-state! :app/datastore assoc :ds/query-tries 0)
+      (save-file-metadata! data)
+      (set-title! "File -" (:kixi.datastore.metadatastore/name data)))))
 
 (defmethod on-query-response
   :error
   [[o data]]
   (reset! dash-query-pending? false)
-  (log/debug ">>>>> GOT ERROR" o data))
+  (log/severe "Query Error:" o data))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; On Route Change
-
-(defn send-dashboard-query!
-  [id]
-  (when-not @dash-query-pending?
-    (reset! dash-query-pending? true)
-    (data/query {:datastore/metadata-with-activities [[[:kixi.datastore.metadatastore/meta-read]]
-                                                      (:full query-fields)]}
-                on-query-response)))
-
-(defn send-single-file-item-query!
-  [id]
-  (data/query {:datastore/metadata-by-id [[id]
-                                          (:full query-fields)]}
-              on-query-response))
 
 (defmulti on-route-change
   (fn [{:keys [args]}] (:route/path args)))
@@ -151,6 +164,7 @@
 (defmethod on-route-change
   :app/data
   [{:keys [args]}]
+  (data/swap-app-state! :app/datastore dissoc :ds/error)
   (data/swap-app-state! :app/datastore assoc :ds/pending? true)
   (let [id (get-in args [:route/params :id])]
     (send-single-file-item-query! id)

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -68,6 +68,7 @@
                     :ds/pending? false
                     :ds/download-pending? false
                     :ds/file-metadata {}
+                    :ds/query-tries 0
                     :ds/activities {:kixi.datastore.metadatastore/meta-read (get-string :string/file-sharing-meta-read)
                                     :kixi.datastore.metadatastore/meta-update (get-string :string/file-sharing-meta-update)
                                     :kixi.datastore.metadatastore/file-read (get-string :string/file-sharing-file-read)}}}
@@ -142,7 +143,10 @@
   (swap-app-state! :app/create-data dissoc :cd/pending-data)
   (swap-app-state! :app/create-data dissoc :cd/pending-data)
   (swap-app-state! :app/user dissoc :user/group-search-results)
-  (swap-app-state! :app/user dissoc :user/group-search-filtered))
+  (swap-app-state! :app/user dissoc :user/group-search-filtered)
+  (swap-app-state! :app/datastore assoc :ds/query-tries 0)
+  (swap-app-state! :app/datastore assoc :ds/current nil)
+  (swap-app-state! :app/datastore dissoc :ds/error))
 
 (defn save-data!
   []

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -78,4 +78,6 @@
                    :ds/pending? s/Bool
                    :ds/download-pending? s/Bool
                    :ds/file-metadata {uuid? s/Any}
-                   :ds/activities {s/Keyword s/Str}}})
+                   :ds/activities {s/Keyword s/Str}
+                   :ds/query-tries s/Num
+                   (s/optional-key :ds/error) s/Keyword}})

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -231,7 +231,8 @@
    :string/file-sharing-file-read           "File Read"
    :string/file-actions-download-file       "Download this file"
    :string/sharing-matrix-group-name        "Group Name"
-   :string/sharing-matrix-group-search-ph   "Search for users and/or groups..."} )
+   :string/sharing-matrix-group-search-ph   "Search for users and/or groups..."
+   :string/file-inaccessible                "The file could not be accessed. Either it does not exist or you do not have permission to view it."} )
 
 (defn resolve-string
   ([r]


### PR DESCRIPTION
This is to avoid the 'too quick' bug following the upload of a file -
may have to up the # of tries or add a small sleep if it doesn't fix
it. Will now also display an error message once the tries are exhausted.