### PR TITLE
Changing gateway to use redirect downloads

### DIFF
--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -109,15 +109,13 @@
            ;; ----------------------------------------------
            [:hr]
            [:div.actions
-            (shared/button {:id :button-a
-                            :icon (if download-pending? icons/loading icons/download)
-                            :txt :string/file-actions-download-file
-                            :class "file-action-download"}
-                           #(when-not download-pending?
-                              (controller/raise! :data/download-file {:id current})))
             [:a {:href (str
                         "http://"
                         (or (cljs-env :witan-api-url) "localhost:30015")
                         "/download?id="
                         current)
-                 :target "_blank"} "Download me"]]])))))
+                 :target "_blank"} (shared/button {:id :button-a
+                                                   :icon icons/download
+                                                   :txt :string/file-actions-download-file
+                                                   :class "file-action-download"}
+                                                  #())]]])))))

--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -7,7 +7,8 @@
             [witan.ui.controller :as controller]
             [witan.ui.utils :as utils]
             [goog.string :as gstring])
-  (:require-macros [cljs-log.core :as log]))
+  (:require-macros [cljs-log.core :as log]
+                   [witan.ui.env :as env :refer [cljs-env]]))
 
 (defn reverse-group->activity-map
   [all-activities sharing]
@@ -36,7 +37,7 @@
      (doall
       (mapcat
        #(vector [:span {:key (str "string-" %1)} %2]
-                [:br {:key (str "br-" %1)}])       
+                [:br {:key (str "br-" %1)}])
        (range (count substrings))
        substrings))]))
 
@@ -113,4 +114,10 @@
                             :txt :string/file-actions-download-file
                             :class "file-action-download"}
                            #(when-not download-pending?
-                              (controller/raise! :data/download-file {:id current})))]])))))
+                              (controller/raise! :data/download-file {:id current})))
+            [:a {:href (str
+                        "http://"
+                        (or (cljs-env :witan-api-url) "localhost:30015")
+                        "/download?id="
+                        current)
+                 :target "_blank"} "Download me"]]])))))

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -127,7 +127,7 @@
   (if (:error data)
     (let [id (first (get-in data [:original :params]))
           tries (data/get-in-app-state :app/datastore :ds/query-tries)]
-      (if (< tries 3)
+      (if (< tries 5)
         (do
           (data/swap-app-state! :app/datastore update :ds/query-tries inc)
           (send-single-file-item-query! id))

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -215,23 +215,6 @@
     (route/navigate! :app/data {:id id})))
 
 (defmethod on-event
-  [:kixi.datastore.filestore/download-link-created "1.0.0"]
-  [{:keys [args]}]
-  (let [{:keys [kixi.comms.event/payload]} args
-        {:keys [kixi.datastore.metadatastore/link]} payload]
-    (data/swap-app-state! :app/datastore assoc :ds/download-pending? false)
-    (log/info "Downloading file" link)
-    (.open js/window link)))
-
-(defmethod on-event
-  [:kixi.datastore.filestore/download-link-rejected "1.0.0"]
-  [{:keys [args]}]
-  (let [{:keys [kixi.comms.event/payload]} args
-        {:keys [reason]} payload]
-    (.alert js/window (str "Unable to download file: " (name reason)))
-    (data/swap-app-state! :app/datastore assoc :ds/download-pending? false)))
-
-(defmethod on-event
   [:kixi.datastore.metadatastore/sharing-change-rejected "1.0.0"]
   [{:keys [args]}]
   (let [{:keys [kixi.comms.event/payload]} args
@@ -261,13 +244,6 @@
   (data/swap-app-state! :app/create-data assoc :cd/pending? true)
   (data/swap-app-state! :app/create-data assoc :cd/pending-data data)
   (data/command! :kixi.datastore.filestore/create-upload-link "1.0.0" nil))
-
-(defmethod handle
-  :download-file
-  [event {:keys [id]}]
-  (data/swap-app-state! :app/datastore assoc :ds/download-pending? true)
-  (data/command! :kixi.datastore.filestore/create-download-link "1.0.0"
-                 {:kixi.datastore.metadatastore/id id}))
 
 (defmethod handle
   :sharing-change

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -67,7 +67,6 @@
                            :rts/pending? false}
     :app/datastore {:ds/current nil
                     :ds/pending? false
-                    :ds/download-pending? false
                     :ds/file-metadata {}
                     :ds/query-tries 0
                     :ds/activities {:kixi.datastore.metadatastore/meta-read (get-string :string/file-sharing-meta-read)

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -8,7 +8,7 @@
 
 (def GroupSchema
   {:kixi.group/name   s/Str
-   :kixi.group/type   s/Keyword
+   :kixi.group/type   s/Str
    :kixi.group/id     uuid?})
 
 (def UserSchema

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -77,7 +77,6 @@
    :app/datastore {(s/optional-key :schema/search-results) [SchemaSchema]
                    :ds/current (s/maybe uuid?)
                    :ds/pending? s/Bool
-                   :ds/download-pending? s/Bool
                    :ds/file-metadata {uuid? s/Any}
                    :ds/activities {s/Keyword s/Str}
                    :ds/query-tries s/Num


### PR DESCRIPTION
We now no longer use commands and events to handle downloads; we hit an endpoint on the gateway which 302's.

https://www.pivotaltracker.com/story/show/138178375