### PR TITLE
Certain activities are now locked on the sharing matrix

### DIFF
--- a/src/cljs/witan/ui/components/icons.cljs
+++ b/src/cljs/witan/ui/components/icons.cljs
@@ -11,6 +11,7 @@
                 :dark "md-dark"
                 :light "md-light"
                 :disabled "md-inactive"
+                :tiny "md-t"
                 :small "md-s"
                 :medium "md-m"
                 :large "md-l"

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -49,7 +49,7 @@
   (zipmap activities
           (map (fn [activity]
                  (vec (keep (fn [[group group-activities]]
-                              (when (get group-activities activity)
+                              (when (get (:values group-activities) activity)
                                 (:kixi.group/id group))) groups))) activities)))
 
 (defn send-dashboard-query!

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -96,7 +96,9 @@
                     :ds/query-tries 0
                     :ds/activities {:kixi.datastore.metadatastore/meta-read (get-string :string/file-sharing-meta-read)
                                     :kixi.datastore.metadatastore/meta-update (get-string :string/file-sharing-meta-update)
-                                    :kixi.datastore.metadatastore/file-read (get-string :string/file-sharing-file-read)}}}
+                                    :kixi.datastore.metadatastore/file-read (get-string :string/file-sharing-file-read)}
+                    :ds/locked-activities [:kixi.datastore.metadatastore/meta-update
+                                           :kixi.datastore.metadatastore/meta-read]}}
    (s/validate ws/AppStateSchema)
    (atomize-map)))
 

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -79,5 +79,6 @@
                    :ds/pending? s/Bool
                    :ds/file-metadata {uuid? s/Any}
                    :ds/activities {s/Keyword s/Str}
+                   :ds/locked-activities [s/Keyword]
                    :ds/query-tries s/Num
                    (s/optional-key :ds/error) s/Keyword}})

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -236,7 +236,8 @@
    :string/file-inaccessible                "The file could not be accessed. Either it does not exist or you do not have permission to view it."
    :string/title-data-dashboard             "Your Files"
    :string/title-data-create                "Upload File"
-   :string/title-data-loading               "Loading..."} )
+   :string/title-data-loading               "Loading..."
+   :string/this-is-you                      "This is you!"} )
 
 (defn resolve-string
   ([r]

--- a/src/styles/witan/ui/style/icons.clj
+++ b/src/styles/witan/ui/style/icons.clj
@@ -6,6 +6,8 @@
 (def style
   [[:.material-icons
     {:font-size (px 32)}]
+   [:.material-icons.md-t
+    {:font-size (px 10)}]
    [:.material-icons.md-s
     {:font-size (px 18)}]
    [:.material-icons.md-m

--- a/src/styles/witan/ui/style/shared.clj
+++ b/src/styles/witan/ui/style/shared.clj
@@ -101,7 +101,10 @@
              [:.group-icon :.schema-icon
               {:display :inline
                :vertical-align :sub
-               :margin-right (em 0.2)}]]
+               :margin-right (em 0.2)}]
+             [:.you
+              {:margin-left (px 4)
+               :cursor :default}]]
 
 ;;;;;;;;;;;;;;
 


### PR DESCRIPTION
This prevents users accidentally removing themself from a dataset. Also
added a small indicator next to the user's self-group (inline-group).