### PR TITLE
Fixed a bug where multiple changes to permissions crashed the app

### DIFF
--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -182,7 +182,8 @@
    (swap-app-state! :app/user dissoc :user/group-search-filtered)
    (swap-app-state! :app/datastore assoc :ds/query-tries 0)
    (swap-app-state! :app/datastore assoc :ds/current nil)
-   (swap-app-state! :app/datastore dissoc :ds/error))
+   (swap-app-state! :app/datastore dissoc :ds/error)
+   (swap-app-state! :app/activities assoc :activities/pending {}))
   ([m]
    (-> m
        (update :app/create-data dissoc :cd/pending-data))))

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -51,8 +51,8 @@
 (def ActivityPendingSchema
   {:activity s/Keyword
    :state s/Any
-   :reporters {:failed s/Str
-               :completed s/Str}
+   :reporters {:failed s/Any
+               :completed s/Any}
    :id uuid?})
 
 ;; app state schema


### PR DESCRIPTION
The crash was a schema violation on save. Save occurs every time an
activity finished. The schema violation was resolved by a) changing
the schema to something more permissive and b) actually adding
pending activities to the custom reset function, so they should never
actually be saved anyway. In order to calm lots of saves in quick
succession, which causes UI lag, the 1s delay before a save is now
reset when a new activity finishes (essentially a debounce).