### PR TITLE
Add ability to create datapacks

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
                  [cljsjs/parinfer "2.0.0-0"]]
 
   :plugins [[lein-figwheel "0.5.4-3" :exclusions [org.clojure/tools.reader]]
-            [lein-cljsbuild "1.1.2" :exclusions [[org.clojure/clojure]]]
+            [lein-cljsbuild "1.1.2" :exclusions [org.clojure/clojure]]
             [lein-garden "0.2.6"]
             [lein-doo "0.1.7"]]
 

--- a/resources/public/img/file-types/pack.svg
+++ b/resources/public/img/file-types/pack.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 56 56" style="enable-background:new 0 0 56 56;" xml:space="preserve">
+<g>
+	<path style="fill:#E9E9E0;" d="M36.985,0H7.963C7.155,0,6.5,0.655,6.5,1.926V55c0,0.345,0.655,1,1.463,1h40.074
+		c0.808,0,1.463-0.655,1.463-1V12.978c0-0.696-0.093-0.92-0.257-1.085L37.607,0.257C37.442,0.093,37.218,0,36.985,0z"/>
+	<polygon style="fill:#D9D7CA;" points="37.5,0.151 37.5,12 49.349,12 	"/>
+	<g>
+		<rect x="26.5" y="42" style="fill:#C8BDB8;" width="2" height="14"/>
+		<polygon style="fill:#C8BDB8;" points="30.5,23 30.5,21 28.5,21 28.5,19 26.5,19 26.5,21 24.5,21 24.5,23 26.5,23 26.5,25 
+			24.5,25 24.5,27 26.5,27 26.5,29 24.5,29 24.5,31 26.5,31 26.5,34 28.5,34 28.5,31 30.5,31 30.5,29 28.5,29 28.5,27 30.5,27 
+			30.5,25 28.5,25 28.5,23 		"/>
+	</g>
+	<g>
+		<rect x="23.5" y="34" style="fill:#CBB292;" width="8" height="8"/>
+		<path style="fill:#5E5F62;" d="M32.5,43h-10V33h10V43z M24.5,41h6v-6h-6V41z"/>
+	</g>
+	<rect x="23.5" y="36" style="fill:#5E5F62;" width="8" height="2"/>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/src/cljs/witan/ui/activities.cljs
+++ b/src/cljs/witan/ui/activities.cljs
@@ -52,7 +52,13 @@
                      [{:kixi.comms.event/key  :kixi.datastore.file-metadata/updated
                        :kixi.comms.event/payload {:kixi.datastore.communication-specs/file-metadata-update-type :kixi.datastore.communication-specs/file-metadata-sharing-updated}}
                       (a/$ :completed)]
-                     [{:kixi.comms.event/key  :kixi.datastore.metadatastore/sharing-change-rejected} (a/$ :failed)])]})
+                     [{:kixi.comms.event/key  :kixi.datastore.metadatastore/sharing-change-rejected} (a/$ :failed)])]
+   ;;
+   :create-datapack [{:kixi.comms.command/key  :kixi.datastore/create-datapack}
+                     (a/or
+                      [{:kixi.comms.event/key  :kixi.datastore.file-metadata/rejected} (a/$ :failed)]
+                      [{:kixi.comms.event/key  :kixi.datastore.file-metadata/updated
+                        :kixi.comms.event/payload {:kixi.datastore.communication-specs/file-metadata-update-type :kixi.datastore.communication-specs/file-metadata-created}} (a/$ :completed)])]})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cljs/witan/ui/components/create_datapack.cljs
+++ b/src/cljs/witan/ui/components/create_datapack.cljs
@@ -54,11 +54,7 @@
   [datapack]
   (let [table-id "create-datapack-files-table"
         select-fn (fn [{:keys [kixi.datastore.metadatastore/id] :as x} & _]
-                    (swap! datapack update :selected-files conj x)
-                    #_(swap! datapack update :sharing-summary assoc id
-                             (update-sharing-summary (data/get-app-state :app/user)
-                                                     (keys (:selected-groups @datapack))
-                                                     x)))]
+                    (swap! datapack update :selected-files conj x))]
     [editable-field
      nil
      [:div.datapack-edit-file
@@ -137,12 +133,10 @@
       (fn [[group activities] activity target-state]
         (swap! datapack assoc-in [:selected-groups group :values activity] target-state)
         (when (every? false? (vals (get-in @datapack [:selected-groups group :values])))
-          (swap! datapack update :selected-groups dissoc group)
-          #_(reset-sharing-summaries! datapack)))
+          (swap! datapack update :selected-groups dissoc group)))
       :on-add
       (fn [g]
-        (swap! datapack assoc-in [:selected-groups g :values] {:kixi.datastore.metadatastore/meta-read true})
-        #_(reset-sharing-summaries! datapack))}
+        (swap! datapack assoc-in [:selected-groups g :values] {:kixi.datastore.metadatastore/meta-read true}))}
      {:exclusions (keys (:selected-groups @datapack))}]]])
 
 (defn create-button-disabled?

--- a/src/cljs/witan/ui/components/create_datapack.cljs
+++ b/src/cljs/witan/ui/components/create_datapack.cljs
@@ -1,15 +1,188 @@
 (ns witan.ui.components.create-datapack
   (:require [reagent.core :as r]
+            [sablono.core :as sab :include-macros true]
             [witan.ui.data :as data]
-            [witan.ui.components.shared :as shared]
+            [witan.ui.components.shared :as shared :refer [editable-field]]
             [witan.ui.components.icons :as icons]
             [witan.ui.strings :refer [get-string]]
             [witan.ui.controller :as controller]
             [witan.ui.utils :as utils]
-            [goog.string :as gstring])
+            [witan.ui.time :as time]
+            [witan.ui.route :as route]
+            [goog.string :as gstring]
+            [clojure.string :as str])
   (:require-macros [cljs-log.core :as log]))
+
+(defn input-wrapper
+  [& inputs]
+  [:form.pure-form
+   {:on-submit #(.preventDefault %)}
+   (vec (cons :div inputs))])
+
+(defn empty-form-data
+  [activities locked-activities]
+  (let [user (data/get-in-app-state :app/user)]
+    {:title ""
+     :selected-files []
+     :sharing-summary {}
+     :selected-groups {{:kixi.group/id (:kixi.user/self-group user)
+                        :kixi.group/name (:kixi.user/name user)
+                        :kixi.group/type "user"}
+                       {:values
+                        (zipmap (keys activities) (repeat true))
+                        :locked (set locked-activities)}}}))
+
+(defn edit-title
+  [datapack]
+  [editable-field
+   nil
+   [:div.datapack-edit-title
+    [:h2.heading (get-string :string/title)]
+    (input-wrapper
+     [:input {:id  "title"
+              :type "text"
+              :placeholder (get-string :string/create-datapack-title-ph)
+              :on-change #(swap! datapack assoc :title (.. % -target -value))}])]])
+
+(defn display-sharing-summary
+  [ddatapack ot]
+  (fn [{:keys [kixi.datastore.metadatastore/id kixi.datastore.metadatastore/sharing]}]
+    (let [group-names (set (map :kixi.group/name (:kixi.datastore.metadatastore/meta-read sharing)))]
+      [shared/collapsible-text (str/join ", "  group-names)])))
+
+(defn edit-files
+  [datapack]
+  (let [table-id "create-datapack-files-table"
+        ot (atom nil)]
+    (r/create-class
+     {:component-did-mount
+      (fn [_]
+        (reset! ot (js/Opentip. (str "#" table-id) "FOOBAR" #js {:showOn nil
+                                                                 :tipJoint "left"
+                                                                 :fixed true
+                                                                 :offset #js [30,-5]})))
+      :reagent-render
+      (fn [datapack]
+        (let [select-fn (fn [{:keys [kixi.datastore.metadatastore/id] :as x} & _]
+                          (swap! datapack update :selected-files conj x)
+                          #_(swap! datapack update :sharing-summary assoc id
+                                   (update-sharing-summary (data/get-app-state :app/user)
+                                                           (keys (:selected-groups @datapack))
+                                                           x)))]
+          [editable-field
+           nil
+           [:div.datapack-edit-file
+            [:h2.heading (get-string :string/files)]
+            [shared/file-search-area
+             {:ph :string/create-datapack-search-files
+              :on-click select-fn
+              :on-init #(controller/raise! :data/refresh-files {})
+              :on-search #(controller/raise! :data/search-files {:search %})
+              :get-results-fn #(data/get-in-app-state :app/datastore :ds/files-search-filtered)
+              :selector-key :kixi.datastore.metadatastore/id
+              :table-headers-fn (fn []
+                                  [{:content-fn #(shared/button {:icon icons/tick
+                                                                 :id (str (:kixi.datastore.metadatastore/id %) "-select")
+                                                                 :prevent? true}
+                                                                identity)
+                                    :title ""  :weight 0.10}
+                                   {:content-fn #(shared/inline-file-title % :small :small)
+                                    :title (get-string :string/file-name)
+                                    :weight 0.50}
+                                   {:content-fn (comp
+                                                 :kixi.user/name
+                                                 :kixi/user
+                                                 :kixi.datastore.metadatastore/provenance)
+                                    :title (get-string :string/file-uploader)
+                                    :weight 0.20}
+                                   {:content-fn (comp
+                                                 time/iso-time-as-moment
+                                                 :kixi.datastore.metadatastore/created
+                                                 :kixi.datastore.metadatastore/provenance)
+                                    :title (get-string :string/file-uploaded-at)
+                                    :weight 0.20}])}
+             {:exclusions (:selected-files @datapack)}]
+            (when (empty? (:selected-files @datapack))
+              [:i [:h4 (get-string :string/create-datapack-no-files)]])
+            [:div
+             {:style {:display (if (empty? (:selected-files @datapack)) "none" "inherit")}}
+             [shared/table
+              {:headers [{:content-fn
+                          #(vector
+                            :div.flex-start
+                            (shared/button {:icon icons/close
+                                            :id (str (:kixi.datastore.metadatastore/id %) "-select")
+                                            :prevent? true}
+                                           (fn [_]
+                                             (swap! datapack update :selected-files
+                                                    (fn [files]
+                                                      (remove #{%} files)))))
+                            (shared/button {:icon icons/search
+                                            :id (str (:kixi.datastore.metadatastore/id %) "-open")
+                                            :prevent? true}
+                                           (fn [_]
+                                             (.open
+                                              js/window
+                                              (str "/#" (route/find-path :app/data {:id (:kixi.datastore.metadatastore/id %)}))))))
+                          :title ""  :weight "90px"}
+                         {:content-fn #(shared/inline-file-title % :small :small)
+                          :title (get-string :string/file-name)
+                          :weight 0.43}
+                         {:content-fn (display-sharing-summary @datapack @ot)
+                          :title (get-string :string/visible-to)
+                          :weight 0.43}]
+               :content (reverse (:selected-files @datapack))
+               :id table-id}]]]]))})))
+
+(defn edit-sharing
+  [datapack activities->string]
+  [editable-field
+   nil
+   [:div.datapack-edit-sharing
+    [:h2 (get-string :string/datapack-sharing)]
+    [shared/sharing-matrix
+     activities->string
+     (:selected-groups @datapack)
+     {:on-change
+      (fn [[group activities] activity target-state]
+        (swap! datapack assoc-in [:selected-groups group :values activity] target-state)
+        (when (every? false? (vals (get-in @datapack [:selected-groups group :values])))
+          (swap! datapack update :selected-groups dissoc group)
+          #_(reset-sharing-summaries! datapack)))
+      :on-add
+      (fn [g]
+        (swap! datapack assoc-in [:selected-groups g :values] {:kixi.datastore.metadatastore/meta-read true})
+        #_(reset-sharing-summaries! datapack))}
+     {:exclusions (keys (:selected-groups @datapack))}]]])
+
+(defn create-button-disabled?
+  [ddatapack]
+  (or (clojure.string/blank? (:title ddatapack))
+      (empty? (:selected-files ddatapack))))
 
 (defn view
   []
-  (fn []
-    [:div "Create Datapack"]))
+  (let [activities->string (data/get-in-app-state :app/datastore :dp/activities)
+        locked-activities (data/get-in-app-state :app/datastore :dp/locked-activities)
+        datapack (r/atom (empty-form-data
+                          activities->string
+                          locked-activities))]
+    (fn []
+      (let [{:keys [cdp/pending? cdp/error] :as cdp} (data/get-in-app-state :app/create-datapack)]
+        [:div#create-datapack-view
+         (shared/header :string/create-new-datapack nil #{:center})
+         [:div.flex-center
+          [:div.container.padded-content
+           (edit-title datapack)
+           [edit-files datapack]
+           (edit-sharing datapack activities->string)
+           [:div.flex-vcenter-start
+            (shared/button {:icon icons/datapack
+                            :id :creats
+                            :txt :string/create
+                            :class "btn-success"
+                            :prevent? true
+                            :disabled? (or pending? (create-button-disabled? @datapack))}
+                           #(controller/raise! :data/create-datapack {:datapack @datapack}))
+            (when (:general error)
+              [:div.error (:general error)])]]]]))))

--- a/src/cljs/witan/ui/components/create_datapack.cljs
+++ b/src/cljs/witan/ui/components/create_datapack.cljs
@@ -45,94 +45,84 @@
               :on-change #(swap! datapack assoc :title (.. % -target -value))}])]])
 
 (defn display-sharing-summary
-  [ddatapack ot]
-  (fn [{:keys [kixi.datastore.metadatastore/id kixi.datastore.metadatastore/sharing]}]
+  [ddatapack]
+  (fn [{:keys [kixi.datastore.metadatastore/sharing]}]
     (let [group-names (set (map :kixi.group/name (:kixi.datastore.metadatastore/meta-read sharing)))]
       [shared/collapsible-text (str/join ", "  group-names)])))
 
 (defn edit-files
   [datapack]
   (let [table-id "create-datapack-files-table"
-        ot (atom nil)]
-    (r/create-class
-     {:component-did-mount
-      (fn [_]
-        (reset! ot (js/Opentip. (str "#" table-id) "FOOBAR" #js {:showOn nil
-                                                                 :tipJoint "left"
-                                                                 :fixed true
-                                                                 :offset #js [30,-5]})))
-      :reagent-render
-      (fn [datapack]
-        (let [select-fn (fn [{:keys [kixi.datastore.metadatastore/id] :as x} & _]
-                          (swap! datapack update :selected-files conj x)
-                          #_(swap! datapack update :sharing-summary assoc id
-                                   (update-sharing-summary (data/get-app-state :app/user)
-                                                           (keys (:selected-groups @datapack))
-                                                           x)))]
-          [editable-field
-           nil
-           [:div.datapack-edit-file
-            [:h2.heading (get-string :string/files)]
-            [shared/file-search-area
-             {:ph :string/create-datapack-search-files
-              :on-click select-fn
-              :on-init #(controller/raise! :data/refresh-files {})
-              :on-search #(controller/raise! :data/search-files {:search %})
-              :get-results-fn #(data/get-in-app-state :app/datastore :ds/files-search-filtered)
-              :selector-key :kixi.datastore.metadatastore/id
-              :table-headers-fn (fn []
-                                  [{:content-fn #(shared/button {:icon icons/tick
-                                                                 :id (str (:kixi.datastore.metadatastore/id %) "-select")
-                                                                 :prevent? true}
-                                                                identity)
-                                    :title ""  :weight 0.10}
-                                   {:content-fn #(shared/inline-file-title % :small :small)
-                                    :title (get-string :string/file-name)
-                                    :weight 0.50}
-                                   {:content-fn (comp
-                                                 :kixi.user/name
-                                                 :kixi/user
-                                                 :kixi.datastore.metadatastore/provenance)
-                                    :title (get-string :string/file-uploader)
-                                    :weight 0.20}
-                                   {:content-fn (comp
-                                                 time/iso-time-as-moment
-                                                 :kixi.datastore.metadatastore/created
-                                                 :kixi.datastore.metadatastore/provenance)
-                                    :title (get-string :string/file-uploaded-at)
-                                    :weight 0.20}])}
-             {:exclusions (:selected-files @datapack)}]
-            (when (empty? (:selected-files @datapack))
-              [:i [:h4 (get-string :string/create-datapack-no-files)]])
-            [:div
-             {:style {:display (if (empty? (:selected-files @datapack)) "none" "inherit")}}
-             [shared/table
-              {:headers [{:content-fn
-                          #(vector
-                            :div.flex-start
-                            (shared/button {:icon icons/close
-                                            :id (str (:kixi.datastore.metadatastore/id %) "-select")
-                                            :prevent? true}
-                                           (fn [_]
-                                             (swap! datapack update :selected-files
-                                                    (fn [files]
-                                                      (remove #{%} files)))))
-                            (shared/button {:icon icons/search
-                                            :id (str (:kixi.datastore.metadatastore/id %) "-open")
-                                            :prevent? true}
-                                           (fn [_]
-                                             (.open
-                                              js/window
-                                              (str "/#" (route/find-path :app/data {:id (:kixi.datastore.metadatastore/id %)}))))))
-                          :title ""  :weight "90px"}
-                         {:content-fn #(shared/inline-file-title % :small :small)
-                          :title (get-string :string/file-name)
-                          :weight 0.43}
-                         {:content-fn (display-sharing-summary @datapack @ot)
-                          :title (get-string :string/visible-to)
-                          :weight 0.43}]
-               :content (reverse (:selected-files @datapack))
-               :id table-id}]]]]))})))
+        select-fn (fn [{:keys [kixi.datastore.metadatastore/id] :as x} & _]
+                    (swap! datapack update :selected-files conj x)
+                    #_(swap! datapack update :sharing-summary assoc id
+                             (update-sharing-summary (data/get-app-state :app/user)
+                                                     (keys (:selected-groups @datapack))
+                                                     x)))]
+    [editable-field
+     nil
+     [:div.datapack-edit-file
+      [:h2.heading (get-string :string/files)]
+      [shared/file-search-area
+       {:ph :string/create-datapack-search-files
+        :on-click select-fn
+        :on-init #(controller/raise! :data/refresh-files {})
+        :on-search #(controller/raise! :data/search-files {:search %})
+        :get-results-fn #(data/get-in-app-state :app/datastore :ds/files-search-filtered)
+        :selector-key :kixi.datastore.metadatastore/id
+        :table-headers-fn (fn []
+                            [{:content-fn #(shared/button {:icon icons/tick
+                                                           :id (str (:kixi.datastore.metadatastore/id %) "-select")
+                                                           :prevent? true}
+                                                          identity)
+                              :title ""  :weight 0.10}
+                             {:content-fn #(shared/inline-file-title % :small :small)
+                              :title (get-string :string/file-name)
+                              :weight 0.50}
+                             {:content-fn (comp
+                                           :kixi.user/name
+                                           :kixi/user
+                                           :kixi.datastore.metadatastore/provenance)
+                              :title (get-string :string/file-uploader)
+                              :weight 0.20}
+                             {:content-fn (comp
+                                           time/iso-time-as-moment
+                                           :kixi.datastore.metadatastore/created
+                                           :kixi.datastore.metadatastore/provenance)
+                              :title (get-string :string/file-uploaded-at)
+                              :weight 0.20}])}
+       {:exclusions (:selected-files @datapack)}]
+      (when (empty? (:selected-files @datapack))
+        [:i [:h4 (get-string :string/create-datapack-no-files)]])
+      [:div
+       {:style {:display (if (empty? (:selected-files @datapack)) "none" "inherit")}}
+       [shared/table
+        {:headers [{:content-fn
+                    #(vector
+                      :div.flex-start
+                      (shared/button {:icon icons/close
+                                      :id (str (:kixi.datastore.metadatastore/id %) "-select")
+                                      :prevent? true}
+                                     (fn [_]
+                                       (swap! datapack update :selected-files
+                                              (fn [files]
+                                                (remove #{%} files)))))
+                      (shared/button {:icon icons/search
+                                      :id (str (:kixi.datastore.metadatastore/id %) "-open")
+                                      :prevent? true}
+                                     (fn [_]
+                                       (.open
+                                        js/window
+                                        (str "/#" (route/find-path :app/data {:id (:kixi.datastore.metadatastore/id %)}))))))
+                    :title ""  :weight "90px"}
+                   {:content-fn #(shared/inline-file-title % :small :small)
+                    :title (get-string :string/file-name)
+                    :weight 0.43}
+                   {:content-fn (display-sharing-summary @datapack)
+                    :title (get-string :string/visible-to)
+                    :weight 0.43}]
+         :content (reverse (:selected-files @datapack))
+         :id table-id}]]]]))
 
 (defn edit-sharing
   [datapack activities->string]
@@ -174,7 +164,7 @@
          [:div.flex-center
           [:div.container.padded-content
            (edit-title datapack)
-           [edit-files datapack]
+           (edit-files datapack)
            (edit-sharing datapack activities->string)
            [:div.flex-vcenter-start
             (shared/button {:icon icons/datapack

--- a/src/cljs/witan/ui/components/dashboard/data.cljs
+++ b/src/cljs/witan/ui/components/dashboard/data.cljs
@@ -40,9 +40,7 @@
                                                              #(navigate-fn {:kixi.datastore.metadatastore/id %})))))
             name-fn #(vector :div.data-name (case (:kixi.datastore.metadatastore/type %)
                                               "stored" (icons/file-type (:kixi.datastore.metadatastore/file-type %) :small)
-                                              "bundle" (icons/bundle-type (:kixi.datastore.metadatastore/bundle-type %) :small)) [:h4 (:kixi.datastore.metadatastore/name %)])
-            ;;name-fn  (fn [f] (vector :div.data-name (shared/inline-file-title f :small :small)))
-            ]
+                                              "bundle" (icons/bundle-type (:kixi.datastore.metadatastore/bundle-type %) :small)) [:h4 (:kixi.datastore.metadatastore/name %)])]
         [:div#data-dash.dashboard
          (shared-dash/header {:title :string/data-dash-title
                               :filter-txt :string/data-dash-filter

--- a/src/cljs/witan/ui/components/dashboard/data.cljs
+++ b/src/cljs/witan/ui/components/dashboard/data.cljs
@@ -22,14 +22,6 @@
   [selected-id _]
   (route/navigate! :app/datapack-create))
 
-(defn file-metadata->dash-display
-  [file-metadata]
-  {:data/id (:kixi.datastore.metadatastore/id file-metadata)
-   :data/name (:kixi.datastore.metadatastore/name file-metadata)
-   :data/file-type (:kixi.datastore.metadatastore/file-type file-metadata)
-   :data/owner-name (get-in file-metadata [:kixi.datastore.metadatastore/provenance :kixi/user :kixi.user/name])
-   :data/created-at (get-in file-metadata [:kixi.datastore.metadatastore/provenance :kixi.datastore.metadatastore/created])})
-
 (defn view
   []
   (let [selected-id (r/atom nil)]
@@ -37,16 +29,20 @@
       (let [raw-data (data/get-app-state :app/data-dash)
             buttons [{:id :datapack :icon icons/datapack :txt :string/create-new-datapack :class "data-upload"}
                      {:id :upload :icon icons/upload :txt :string/upload-new-data :class "data-upload"}]
-            modified-fn #(vector :div (time/iso-time-as-moment (:data/created-at %)))
-            datasets (mapv file-metadata->dash-display (:items raw-data))
+            modified-fn #(vector :div (time/iso-time-as-moment (get-in % [:kixi.datastore.metadatastore/provenance :kixi.datastore.metadatastore/created])))
+            datasets (:items raw-data)
             selected-id' @selected-id
-            navigate-fn #(route/navigate! :app/data {:id (str (:data/id %))})
-            actions-fn (fn [d] (when (= (:data/id d) selected-id')
+            navigate-fn #(route/navigate! :app/data {:id (:kixi.datastore.metadatastore/id %)})
+            actions-fn (fn [d] (when (= (:kixi.datastore.metadatastore/id d) selected-id')
                                  (vector :div (shared/button {:icon icons/search
                                                               :txt :string/view
-                                                              :id (:data/id d)}
-                                                             #(navigate-fn {:data/id %})))))
-            name-fn #(vector :div.data-name (icons/file-type (:data/file-type %) :small) (:data/name %))]
+                                                              :id (:kixi.datastore.metadatastore/id d)}
+                                                             #(navigate-fn {:kixi.datastore.metadatastore/id %})))))
+            name-fn #(vector :div.data-name (case (:kixi.datastore.metadatastore/type %)
+                                              "stored" (icons/file-type (:kixi.datastore.metadatastore/file-type %) :small)
+                                              "bundle" (icons/bundle-type (:kixi.datastore.metadatastore/bundle-type %) :small)) [:h4 (:kixi.datastore.metadatastore/name %)])
+            ;;name-fn  (fn [f] (vector :div.data-name (shared/inline-file-title f :small :small)))
+            ]
         [:div#data-dash.dashboard
          (shared-dash/header {:title :string/data-dash-title
                               :filter-txt :string/data-dash-filter
@@ -57,7 +53,7 @@
           (shared/table {:headers [{:content-fn name-fn
                                     :title (get-string :string/forecast-name)
                                     :weight 0.45}
-                                   {:content-fn :data/owner-name
+                                   {:content-fn (comp :kixi.user/name :kixi/user :kixi.datastore.metadatastore/provenance)
                                     :title (get-string :string/file-uploader)
                                     :weight 0.2}
                                    {:content-fn modified-fn
@@ -67,6 +63,6 @@
                                     :title ""
                                     :weight 0.15}]
                          :content datasets
-                         :selected?-fn #(= (:data/id %) selected-id')
-                         :on-select #(reset! selected-id (:data/id %))
+                         :selected?-fn #(= (:kixi.datastore.metadatastore/id %) selected-id')
+                         :on-select #(reset! selected-id (:kixi.datastore.metadatastore/id %))
                          :on-double-click navigate-fn})]]))))

--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -3,7 +3,7 @@
             [sablono.core :as sab :include-macros true]
             [witan.ui.data :as data]
             [witan.ui.route :as route]
-            [witan.ui.components.shared :as shared]
+            [witan.ui.components.shared :as shared :refer [editable-field]]
             [witan.ui.components.icons :as icons]
             [witan.ui.strings :refer [get-string]]
             [witan.ui.controller :as controller]
@@ -92,21 +92,6 @@
                 [:br {:key (str "br-" %1)}])
        (range (count substrings))
        substrings))]))
-
-(defn editable-field
-  [on-edit-fn & render-fns]
-  (let [state (r/atom :idle)]
-    (fn [on-edit-fn & render-fns]
-      [:div.editable-field
-       {:on-mouse-over #(reset! state :hovered)
-        :on-mouse-leave #(reset! state :idle)}
-       (vec (cons :div.editable-field-content
-                  (conj
-                   (vec render-fns)
-                   (when (and on-edit-fn (= :hovered @state))
-                     [:span.clickable-text.edit-label
-                      {:on-click on-edit-fn}
-                      (get-string :string/edit)]))))])))
 
 (defn title
   [{:keys [kixi.datastore.metadatastore/name

--- a/src/cljs/witan/ui/components/icons.cljs
+++ b/src/cljs/witan/ui/components/icons.cljs
@@ -96,6 +96,10 @@
   [& args]
   (apply create-key "open_in_browser" args))
 
+(defn view
+  [& args]
+  (apply create-key "visibility" args))
+
 (defn error
   [& args]
   (apply create-key "error" args))
@@ -198,14 +202,13 @@
 
 (defn datapack
   [& args]
-  (apply create-key "folder" args))
+  (apply create-key "library_books" args))
 
 ;;
 
 (defn ext->file-type
   [ext]
-  (condp = ext
-    "csv"  "csv"
+  (case ext
     "ai"   "ai"
     "avi"  "avi"
     "css"  "css"
@@ -247,6 +250,17 @@
            :alt attr
            :title attr
            :class (str "icon--file-type " (when size (name size)))}]))
+
+(defn bundle-type
+  [type & [size]]
+  (case type
+    "datapack" (let [attr (str "zip-1 icon (designed by Madebyoliver from Flaticon)")]
+                 [:img {:src (str "/img/file-types/pack.svg")
+                        :alt attr
+                        :title attr
+                        :class (str "icon--file-type " (when size (name size)))}])
+    ;;
+    (help)))
 
 ;;
 
@@ -330,6 +344,7 @@
                     ["person"        person]
                     ["plus"          plus]
                     ["open"          open]
+                    ["view"          view]
                     ["error"         error]
                     ["clipboard"     clipboard]
                     ["close"         close]

--- a/src/cljs/witan/ui/components/shared.cljs
+++ b/src/cljs/witan/ui/components/shared.cljs
@@ -3,12 +3,15 @@
             [sablono.core :as sab :include-macros true]
             ;;
             [witan.ui.data :as data]
+            [witan.ui.utils :as utils]
+            [goog.string :as gstring]
             [witan.ui.controller :as controller]
             [witan.ui.strings :refer [get-string]]
             [witan.ui.components.icons :as icons])
   (:require-macros
    [devcards.core :as dc :refer [defcard]]
-   [cljs-log.core :as log]))
+   [cljs-log.core :as log]
+   [cljs.core.async.macros :refer [go]]))
 
 (defn search-filter
   [placeholder on-input & [{:keys [id disabled?]}]]
@@ -32,14 +35,23 @@
                    (.preventDefault e))}]]]])
 
 (defn table
-  [{:keys [headers content selected?-fn on-select on-double-click]}]
+  [{:keys [headers content selected?-fn on-select on-double-click on-scroll id]
+    :or {id (str (random-uuid))}}]
   [:div.shared-table
+   {:id id
+    :on-scroll (fn [e]
+                 (when on-scroll
+                   (let [el (.getElementById js/document id)
+                         d (/ (.-scrollTop el) (- (.-scrollHeight el) (.-offsetHeight el)))]
+                     (on-scroll d))))}
    [:table.pure-table.pure-table-horizontal.shared-table-headers
     [:thead
      [:tr
       (doall
        (for [{:keys [title weight]} headers]
-         (let [percent (str (* 100 weight) "%")]
+         (let [percent (if (string? weight)
+                         weight
+                         (str (* 100 weight) "%"))]
            [:th {:key title
                  :style {:width percent}} title])))]]]
    (if-not content
@@ -47,13 +59,15 @@
      [:table.pure-table.pure-table-horizontal.shared-table-rows
       [:tbody
        (doall
-        (for [row content]
+        (for [[i row] (map-indexed vector content)]
           [:tr
-           {:key (apply str row)
+           {:key (str id "--" i)
             :class (when (and selected?-fn (selected?-fn row)) "selected")}
            (doall
             (for [{:keys [content-fn title weight]} headers]
-              (let [percent (str (* 100 weight) "%")]
+              (let [percent (if (string? weight)
+                              weight
+                              (str (* 100 weight) "%"))]
                 [:td {:style {:width percent}
                       :key (apply str row title)
 
@@ -67,8 +81,11 @@
   ([title-string]
    (header-string title-string nil))
   ([title-string subtitle-string]
+   (header-string title-string nil nil))
+  ([title-string subtitle-string opts]
    [:div.shared-heading
-    {:key "heading"}
+    {:key "heading"
+     :class (when (contains? opts :center) "center-string")}
     [:h1 title-string]
     (when subtitle-string
       [:h2 subtitle-string])]))
@@ -77,7 +94,9 @@
   ([title]
    (header-string (get-string title) nil))
   ([title subtitle]
-   (header-string (get-string title) (get-string subtitle))))
+   (header-string (get-string title) (when subtitle (get-string subtitle))))
+  ([title subtitle opts]
+   (header-string (get-string title) (when subtitle (get-string subtitle)) opts)))
 
 (defn button
   [{:keys [icon txt class id prevent? disabled?]} on-button-click]
@@ -119,7 +138,8 @@
 
 (defn inline-file-title
   [{:keys [kixi.datastore.metadatastore/name
-           kixi.datastore.metadatastore/file-type]} size-text size-icon]
+           kixi.datastore.metadatastore/file-type
+           kixi.datastore.metadatastore/bundle-type]} size-text size-icon]
   (let [size-el (condp = size-text
                   :div     :div
                   :span    :span
@@ -129,7 +149,9 @@
                   :large   :h2
                   :x-large :h1)]
     [:div.shared-inline-file-title
-     (icons/file-type file-type size-icon)
+     (cond
+       file-type   (icons/file-type file-type size-icon)
+       bundle-type (icons/bundle-type bundle-type size-icon))
      [size-el name]]))
 
 (defn index
@@ -265,6 +287,62 @@
            {:on-click close-fn}
            (icons/close)]]]))))
 
+;; Experimenting with a new style of search area
+(defn file-search-area
+  [{:keys [on-init]} & _]
+  (let [show-breakout? (r/atom false)
+        selected-group (r/atom nil)
+        num-results (r/atom 10)
+        table-id (str (random-uuid))]
+    (when on-init
+      (on-init))
+    (fn [{:keys [ph on-click on-init get-results-fn selector-key on-search table-headers-fn]} & [opts]]
+      (let [{:keys [id disabled? exclusions]
+             :or {id (str "search-field-"ph)
+                  disabled? false
+                  exclusions nil}} opts
+            results (take @num-results (get-results-fn))
+            results (if exclusions
+                      (let [excluded-groups (map selector-key exclusions)]
+                        (remove (fn [x] (some #{(selector-key x)} excluded-groups)) results))
+                      results)
+            soft-reset-fn (fn []
+                            (when-let [el (.getElementById js/document table-id)]
+                              (set! (.-scrollTop el) 0))
+                            (reset! num-results 10)
+                            (reset! show-breakout? false))
+            close-fn (fn [& _]
+                       (aset (.getElementById js/document id) "value" nil)
+                       (reset! selected-group nil)
+                       (soft-reset-fn))
+            select-fn (fn [final? group]
+                        (when on-click
+                          (on-click group final?))
+                        (reset! selected-group group)
+                        (when final?
+                          (close-fn)))]
+        [:div.shared-search-area
+         (search-filter (get-string ph)
+                        #(if (clojure.string/blank? %)
+                           (soft-reset-fn)
+                           (do (reset! show-breakout? true)
+                               (on-search %)))
+                        {:id id
+                         :disabled? disabled?})
+         [:div.breakout-area
+          {:style {:height (if @show-breakout? "300px" "0px")}}
+          (table {:id table-id
+                  :headers (table-headers-fn)
+                  :content results
+                  :selected?-fn #(= (selector-key %) (selector-key @selected-group))
+                  :on-select (partial select-fn true)
+                  :on-double-click (partial select-fn true)
+                  :on-scroll #(if (> % 1.0)
+                                (swap! num-results + 10))})
+          [:div.close
+           {:on-click close-fn}
+           (icons/close)]]]))))
+
 (defn sharing-matrix
   [sharing-activites group->activities
    {:keys [on-change on-add all-disabled? show-search?]
@@ -335,6 +413,34 @@
        (icons/close)])
     [:span tag-string]]))
 
+(defn editable-field
+  [on-edit-fn & render-fns]
+  (let [state (r/atom :idle)]
+    (fn [on-edit-fn & render-fns]
+      [:div.editable-field
+       {:on-mouse-over #(reset! state :hovered)
+        :on-mouse-leave #(reset! state :idle)}
+       (vec (cons :div.editable-field-content
+                  (conj
+                   (vec render-fns)
+                   (when (and on-edit-fn (= :hovered @state))
+                     [:span.clickable-text.edit-label
+                      {:on-click on-edit-fn}
+                      (get-string :string/edit)]))))])))
+
+(defn collapsible-text
+  [long-text]
+  (let [expanded? (r/atom false)]
+    (fn [long-text]
+      [:div.shared-collapsible-text.flex-start
+       [:div
+        {:class (when-not @expanded? "rotate270")
+         :on-click #(swap! expanded? not)}
+        (icons/tree-arrow-down)]
+       [:span
+        {:class (when-not @expanded? "ellipsis")}
+        long-text]])))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; DEVCARDS
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -390,6 +496,13 @@
     [:div (inline-file-title {:kixi.datastore.metadatastore/name "Foo Bar" :kixi.datastore.metadatastore/file-type "csv"} :large :medium)]
     [:div (inline-file-title {:kixi.datastore.metadatastore/name "Foo Bar" :kixi.datastore.metadatastore/file-type "csv"} :medium :small)]
     [:div (inline-file-title {:kixi.datastore.metadatastore/name "Foo Bar" :kixi.datastore.metadatastore/file-type "csv"} :small :tiny)]]))
+
+(defcard inline-file-title-bundles
+  (sab/html
+   [:div
+    [:div (inline-file-title {:kixi.datastore.metadatastore/name "Foo Bar" :kixi.datastore.metadatastore/bundle-type "datapack"} :large :medium)]
+    [:div (inline-file-title {:kixi.datastore.metadatastore/name "Foo Bar" :kixi.datastore.metadatastore/bundle-type "datapack"} :medium :small)]
+    [:div (inline-file-title {:kixi.datastore.metadatastore/name "Foo Bar" :kixi.datastore.metadatastore/bundle-type "datapack"} :small :tiny)]]))
 
 (defcard inline-group
   (sab/html
@@ -483,6 +596,46 @@
    :frame true
    :history false})
 
+;;{:ph :string/create-datapack-search-files
+;;:on-click #(swap! data assoc :selected-file %1)
+;;:on-init #(controller/raise! :data/refresh-metadata {})
+;;:on-search #(controller/raise! :user/search-groups {:search %})
+;;:get-results-fn #(:user/group-search-filtered (data/get-app-state :app/user))
+;;:selector-key :kixi.datastore.metadatastore/id}
+
+(defcard file-search-area
+  (fn [data _]
+    (sab/html
+     [:div
+      {:style {:width "100%"}}
+      (r/as-element
+       [file-search-area
+        {:ph :string/create-datapack-search-files
+         :on-click #(swap! data assoc :selected-file %1)
+         :on-init identity
+         :on-search #(swap! data assoc :search-results
+                            (keep (fn [s]
+                                    (when (gstring/caseInsensitiveContains (:kixi.datastore.metadatastore/name s) %)
+                                      s)) (:all-files @data)))
+         :get-results-fn #(:search-results @data)
+         :selector-key :kixi.datastore.metadatastore/id
+         :table-headers-fn (fn [selector-key select-fn]
+                             [{:content-fn #(button {:icon icons/tick
+                                                     :id (selector-key %)
+                                                     :prevent? true}
+                                                    (fn [_] (select-fn true %)))
+                               :title ""  :weight 0.12}
+                              {:content-fn #(inline-file-title % :small :small) :title (get-string :string/file-name) :weight 0.50}
+                              {:content-fn :kixi.datastore.metadatastore/created :title (get-string :string/file-uploaded-at) :weight 0.38}])}])]))
+  {:selected-file nil
+   :all-files (vec (map-indexed (fn [i s]
+                                  {:kixi.datastore.metadatastore/id (str i)
+                                   :kixi.datastore.metadatastore/name (str (:name s) " " i)}) (concat states states)))
+   :search-results []}
+  {:inspect-data false
+   :frame true
+   :history false})
+
 (defcard sharing-matrix
   (fn [data _]
     (sab/html
@@ -557,3 +710,25 @@
          "Closeable"
          (doall (for [t (take 5 (drop 10 state-names))]
                   (tag t identity identity)))]]))))
+
+(defcard editable-field
+  (fn [data _]
+    (sab/html
+     [:div
+      {:style {:width "100%"}}
+      (r/as-element
+       [editable-field
+        nil
+        [:div "Just a card, no editing."]])
+      (r/as-element
+       [editable-field
+        identity
+        [:div "Hover to edit."]])])))
+
+(defcard collapsible-text
+  (fn [data _]
+    (sab/html
+     [:div
+      {:style {:width "100%"}}
+      (r/as-element
+       [collapsible-text (clojure.string/join "," (map :name states))])])))

--- a/src/cljs/witan/ui/components/shared.cljs
+++ b/src/cljs/witan/ui/components/shared.cljs
@@ -596,13 +596,6 @@
    :frame true
    :history false})
 
-;;{:ph :string/create-datapack-search-files
-;;:on-click #(swap! data assoc :selected-file %1)
-;;:on-init #(controller/raise! :data/refresh-metadata {})
-;;:on-search #(controller/raise! :user/search-groups {:search %})
-;;:get-results-fn #(:user/group-search-filtered (data/get-app-state :app/user))
-;;:selector-key :kixi.datastore.metadatastore/id}
-
 (defcard file-search-area
   (fn [data _]
     (sab/html

--- a/src/cljs/witan/ui/controllers/workspace.cljs
+++ b/src/cljs/witan/ui/controllers/workspace.cljs
@@ -39,12 +39,12 @@
        [:function/name
         :function/id
         :function/version]}
-    (data/query `[{[:workspace/list-by-owner ~id]
-                   [:workspace/name
-                    :workspace/id
-                    :workspace/owner-name
-                    :workspace/modified]}]
-                on-receive)))
+    #_(data/query `[{[:workspace/list-by-owner ~id]
+                     [:workspace/name
+                      :workspace/id
+                      :workspace/owner-name
+                      :workspace/modified]}]
+                  on-receive)))
 
 (defn set-result-downloading!
   ([result dling?]
@@ -222,7 +222,7 @@
                           :workspace/owner-id
                           :workspace/description
                           :workspace/modified]]
-    (data/query `[{[:workspace/by-id ~workspace-id] ~workspace-fields}] on-receive)))
+    #_(data/query `[{[:workspace/by-id ~workspace-id] ~workspace-fields}] on-receive)))
 
 (defmethod on-route-change
   :app/workspace-dash
@@ -269,21 +269,21 @@
 (defmethod handle :fetch-models
   [_ _]
   (log/debug "Fetching models....")
-  (data/query [{:workspace/available-models [:metadata]}] on-receive))
+  #_(data/query [{:workspace/available-models [:metadata]}] on-receive))
 
 (defmethod handle :select-model
   [_ {:keys [name version]}]
   (log/debug "Fetching model" name version)
-  (data/query `[{[:workspace/model-by-name-and-version ~name ~version]
-                 [:workflow :catalog :metadata]}]
-              #(let [[_ {:keys [workflow catalog]}] %]
-                 (on-receive %)
-                 (data/swap-app-state!
-                  :app/workspace assoc-in [:workspace/current :workspace/workflow]
-                  workflow)
-                 (data/swap-app-state!
-                  :app/workspace assoc-in [:workspace/current :workspace/catalog]
-                  catalog))))
+  #_(data/query `[{[:workspace/model-by-name-and-version ~name ~version]
+                   [:workflow :catalog :metadata]}]
+                #(let [[_ {:keys [workflow catalog]}] %]
+                   (on-receive %)
+                   (data/swap-app-state!
+                    :app/workspace assoc-in [:workspace/current :workspace/workflow]
+                    workflow)
+                   (data/swap-app-state!
+                    :app/workspace assoc-in [:workspace/current :workspace/catalog]
+                    catalog))))
 
 (defmethod handle :run-current
   [_ _]

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -85,6 +85,7 @@
     :app/workspace-dash {:wd/workspaces nil}
     :app/data-dash {}
     :app/create-data {:cd/pending? false}
+    :app/create-datapack {:cdp/pending? false}
     :app/rts-dash {}
     :app/workspace-results []
     :app/panic-message nil
@@ -103,6 +104,10 @@
                                     :kixi.datastore.metadatastore/meta-update (get-string :string/file-sharing-meta-update)
                                     :kixi.datastore.metadatastore/file-read (get-string :string/file-sharing-file-read)}
                     :ds/locked-activities [:kixi.datastore.metadatastore/meta-update
+                                           :kixi.datastore.metadatastore/meta-read]
+                    :dp/activities {:kixi.datastore.metadatastore/meta-read (get-string :string/file-sharing-meta-read)
+                                    :kixi.datastore.metadatastore/meta-update (get-string :string/file-sharing-meta-update)}
+                    :dp/locked-activities [:kixi.datastore.metadatastore/meta-update
                                            :kixi.datastore.metadatastore/meta-read]}
     :app/activities {:activities/log []
                      :activities/pending {}}}
@@ -326,7 +331,7 @@
              :kixi.comms.query/body query}]
       (swap! query-responses assoc id cb)
       (send-ws! m))
-    (throw (js/Error. "Query needs to be a map"))))
+    (throw (js/Error. (str "Query needs to be a map:" (pr-str query))))))
 
 (defn command!
   [command-key version params]

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -106,7 +106,13 @@
                    :ds/file-properties FilePropertiesSchema
                    :ds/activities {s/Keyword s/Str}
                    :ds/locked-activities [s/Keyword]
+                   :dp/activities {s/Keyword s/Str}
+                   :dp/locked-activities [s/Keyword]
                    :ds/query-tries s/Num
+                   (s/optional-key :ds/files-search-filtered) [s/Any]
                    (s/optional-key :ds/error) s/Keyword}
+   :app/create-datapack {:cdp/pending? s/Bool
+                         (s/optional-key :cdp/pending-datapack) s/Any
+                         (s/optional-key :cdp/error) {s/Keyword s/Str}}
    :app/activities {:activities/log [ActivityLogSchema]
                     :activities/pending {uuid? ActivityPendingSchema}}})

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -4,10 +4,12 @@
    [cljs-log.core :as log]))
 
 (def strings
-  {:string/name                             "Name"
+  {:string/support-email                    "witan@mastodonc.com"
+   :string/name                             "Name"
    :string/type                             "Type"
    :string/full-name                        "Full Name"
    :string/file-name                        "Title"
+   :string/title                            "Title"
    :string/file-type                        "Dataset Type"
    :string/file-provenance-source           "Source"
    :string/sign-in-failure                  "There was a problem with your details. Please try again."
@@ -28,7 +30,7 @@
    :string/forecast-lastmodified            "Last Modified"
    :string/create-account-header            "Need an account?"
    :string/view                             "View"
-   :string/if-persists                      "If the problem persists, please contact us at witan@mastodonc.com"
+   :string/if-persists                      ["If the problem persists, please contact us at" :string/support-email]
    :string/api-failure                      ["Sorry, we're having a problem with the service. Please try again." :string/if-persists]
    :string/thanks                           "Thanks"
    :string/upload                           "Upload"
@@ -184,6 +186,8 @@
    :string/title-data-dashboard             "Your Datasets"
    :string/title-data-create                "Upload Dataset"
    :string/title-data-loading               "Loading..."
+   :string/calculating                      "Calculating..."
+   :string/waiting                          "Waiting..."
    :string/this-is-you                      "This is you!"
    :string/upload-finalizing                "Confirming the upload succeeded"
    :string/uploading                        "Uploading"
@@ -236,15 +240,31 @@
    :string/activity                         "Activity"
    :string/activity-desc                    "All your activity in this session"
    :string/no-activity                      "There has been no activity recorded in this session"
+   :string/datapack-name                    "Datapack title"
    :string/file-name-too-short              [:string/file-name " must be not be empty"]
+   :string/datapack-name-too-short          [:string/datapack-name " must be not be empty"]
    :string/create-new-datapack              "Create a new datapack"
+   :string/create-datapack-title-ph         "Give your datapack a descriptive and relevant name, e.g. 'Greenway Project'"
+   :string/datapack-sharing                 "Datapack sharing"
+   :string/files                            "Files"
+   :string/create-datapack-search-files     "Search for files by their titles..."
+   :string/create-datapack-no-files         "You have not yet added any files to the datapack. Use the search box to select the files you would like to add."
+   :string/sharing-summary-transparent      "OK!"
+   :string/sharing-summary-translucent      "Warnings"
+   :string/sharing-summary-trans-meta-read  ["The following participants are missing<br/><strong>" :string/file-sharing-meta-read "</strong> permissions:"]
+   :string/sharing-summary-trans-file-read  ["The following participants are missing<br/><strong>" :string/file-sharing-file-read "</strong> permissions:"]
+   :string/na                               "n/a"
+   :string/create-datapack-fail-invalid     ["There was a problem creating the datapack. Please contact support."]
+   :string/visible-to                       "Visible to"
    ;;
-   :string.activity.upload-file/failed          "You failed to upload the file '%s'."
-   :string.activity.upload-file/completed       "You successfully uploaded the file '%s'."
+   :string.activity.upload-file/failed          "You failed to upload the file '%s'"
+   :string.activity.upload-file/completed       "You successfully uploaded the file '%s'"
    :string.activity.update-metadata/failed      "You failed to update the metadata for file '%s' (%s) - %s"
    :string.activity.update-metadata/completed   "You successfully updated the metadata for file '%s' (%s)"
    :string.activity.update-sharing/failed       "You failed to update the sharing details for file '%s'"
    :string.activity.update-sharing/completed    "You successfully updated the sharing details for file '%s' (%s: %s)"
+   :string.activity.create-datapack/failed      "You failed to create the datapack '%s'"
+   :string.activity.create-datapack/completed   "You successfully created the datapack '%s'"
    })
 
 

--- a/src/js/externs.js
+++ b/src/js/externs.js
@@ -17,3 +17,9 @@ var pym = {
         }
     }
 }
+
+// Opentip
+var Opentip = function() {};
+Opentip.prototype = {"show": function () {},
+                     "hide": function () {},
+                     "setContent": function () {}}

--- a/src/styles/witan/ui/style.clj
+++ b/src/styles/witan/ui/style.clj
@@ -18,6 +18,7 @@
             [witan.ui.style.components.results :as results]
             [witan.ui.style.components.rts :as rts]
             [witan.ui.style.components.data :as data]
+            [witan.ui.style.components.datapack :as datapack]
             [witan.ui.style.components.activities :as activities]
 
 
@@ -43,6 +44,7 @@
     results/style
     rts/style
     data/style
+    datapack/style
     activities/style
     ;;
     splitjs/style]

--- a/src/styles/witan/ui/style/app.clj
+++ b/src/styles/witan/ui/style/app.clj
@@ -40,6 +40,11 @@
               :align-items :flex-start
               :justify-content :space-between}]
 
+            [:.flex-start
+             {:display :flex
+              :align-items :flex-start
+              :justify-content :flex-start}]
+
             [:.flex-center
              {:display :flex
               :align-items :flex-start
@@ -50,6 +55,11 @@
               :align-items :center
               :justify-content :space-between}]
 
+            [:.flex-vcenter-start
+             {:display :flex
+              :align-items :center
+              :justify-content :flex-start}]
+
             [:.flex-3
              {:flex [[0.315 1 :auto]]
               :align-self :auto
@@ -59,6 +69,11 @@
              {:flex [[0.493 1 :auto]]
               :align-self :auto
               :width 0}]
+
+            [:.ellipsis
+             {:white-space :nowrap
+              :overflow :hidden}
+             ^:prefix {:text-overflow :ellipsis}]
 
              ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
             ;; Create Workspace
@@ -226,7 +241,7 @@
              [:i
               {:margin-right (px 6)}]
              [:div.hero-content
-              {:margin (px 5)}]
+              {:margin [[(px 5) (px 20) (px 5) (px 5)]]}]
              [:div.hero-close
               {:position :absolute
                :right (px 1)

--- a/src/styles/witan/ui/style/components/data.clj
+++ b/src/styles/witan/ui/style/components/data.clj
@@ -34,8 +34,6 @@
                [:#submit-button
                 {:margin-bottom (px 20)}]
                [:.pure-form
-                [:i
-                 {:font-size (px 20)}]
                 [:.button-container
                  {:margin-top (px 6)}
                  [:button {:margin (px 0)}]]]
@@ -102,10 +100,8 @@
              [:.data-name
               {:display :flex
                :align-items :center}
-              [:span
-               {:vertical-align :top
-                :line-height 2.1
-                :margin-left (px 10)}]]]
+              [:h4
+               {:margin [[(px 0) (px 0) (px 0) (px 10)]]}]]]
 
             [:#data-view
              {:width (percent 100)
@@ -198,37 +194,4 @@
 
              [:.file-edit-geography
               [:input
-               {:margin-top (em 0.3)}]]
-
-             [:.editable-field
-              {:padding [[(em 1) (px 0) (em 1) (em 1)]]
-               :margin-bottom (em 1)
-               ;;:width (percent 100)
-               :line-height (em 1.7)
-               :border-color colour/subtle-grey
-               :border-radius (px 2)
-               :box-shadow [[(px 0) (px 1) (px 4) "rgba(0,0,0,.14)"]]}
-              [:&:hover
-               {}]
-              [:span.clickable-text.edit-label
-               {:font-size (px 12)
-                :height (em 0.75)
-                :line-height (em 0.75)
-                :position :absolute
-                :right (px 20)}]
-              [:.heading
-               {:margin-top (em 0)}]
-              [:.intro
-               {:line-height (em 1.5)
-                :display :block
-                :font-size (px 11)
-                :color 'dimgrey
-                :margin-bottom (em 1)}]
-
-              [:.editable-field-content
-               {:display :flex
-                :justify-content :space-between
-                :vertical-align :bottom
-                :align-items :flex-end}]]
-             [:.editable-field-editing
-              {}]]])
+               {:margin-top (em 0.3)}]]]])

--- a/src/styles/witan/ui/style/components/datapack.clj
+++ b/src/styles/witan/ui/style/components/datapack.clj
@@ -1,0 +1,41 @@
+(ns witan.ui.style.components.datapack
+  (:require [garden.units :refer [px em percent]]
+            [witan.ui.style.colour :as colour]
+            [witan.ui.style.values :as values]
+            [witan.ui.style.fonts :as fonts]
+            [witan.ui.style.util :refer [transition]]))
+
+(def style
+  [[:#create-datapack-view
+    {:width (percent 100)
+     :height (percent 100)
+     :overflow-y :auto
+     :overflow-x :hidden}
+    [:#create-datapack-files-table
+     [:table
+      {:table-layout :fixed}]
+     [:.shared-table :tbody :tr
+      {:cursor :default}
+      [:&:hover
+       {:background-color 'transparent}]]]
+    [:.container
+     {:position :relative
+      :max-width (px 1024)
+      :width (percent 100)}
+     [:div.hero-notification
+      {:padding (px 10)
+       :margin (px 4)}]]
+    [:.datapack-edit-title
+     [:input
+      {:margin-bottom (em 1)}]]
+    [:.datapack-edit-sharing :.datapack-edit-title :.datapack-edit-file
+     {:width (percent 100)
+      :padding-right (em 1)}]
+    [:.datapack-edit-title :.datapack-edit-file
+     [:input
+      {:width (percent 100)}]]
+    [:.sharing-summary
+     [:i
+      {:margin-right (em 0.3)}]]
+    [:div.error
+     {:margin-left (em 1)}]]])

--- a/src/styles/witan/ui/style/shared.clj
+++ b/src/styles/witan/ui/style/shared.clj
@@ -129,9 +129,7 @@
               {:vertical-align :middle}]
              [:button
               {:margin-left (em 0.5)
-               :box-shadow [[(px 2) (px 2) (px 4) colour/box-shadow]]}
-              #_[:i
-                 {:margin [[(px -3) (px 5) (px 0) (px 0)]]}]]]
+               :box-shadow [[(px 2) (px 2) (px 4) colour/box-shadow]]}]]
 
 ;;;;;;;;;;;;;;
 
@@ -314,7 +312,6 @@
             [:.editable-field
              {:padding [[(em 1) (px 0) (em 1) (em 1)]]
               :margin-bottom (em 1)
-              ;;:width (percent 100)
               :line-height (em 1.7)
               :border-color colour/subtle-grey
               :border-radius (px 2)

--- a/src/styles/witan/ui/style/shared.clj
+++ b/src/styles/witan/ui/style/shared.clj
@@ -13,6 +13,7 @@
                :margin         (em 0.24)}]
              [:input
               {:padding-left (px 30)
+               :height       (px 34)
                :width        (percent 100)}]]
 
 ;;;;;;;;;;;;;;
@@ -92,7 +93,11 @@
                :vertical-align :super
                :margin-left (em 1)}
               [:form
-               {:width (em 32)}]]]
+               {:width (em 32)}]]
+             [:&.center-string
+              [:h1
+               {:width (percent 100)
+                :text-align :center}]]]
 
 ;;;;;;;;;;;;;;
 
@@ -125,8 +130,8 @@
              [:button
               {:margin-left (em 0.5)
                :box-shadow [[(px 2) (px 2) (px 4) colour/box-shadow]]}
-              [:i
-               {:margin [[(px -3) (px 5) (px 0) (px 0)]]}]]]
+              #_[:i
+                 {:margin [[(px -3) (px 5) (px 0) (px 0)]]}]]]
 
 ;;;;;;;;;;;;;;
 
@@ -205,7 +210,7 @@
 
 ;;;;;;;;;;;;;;;
 
-            [:.shared-schema-search-area :.shared-group-search-area
+            [:.shared-schema-search-area :.shared-group-search-area :.shared-search-area
              [:div.breakout-area
               {:display :flex
                :overflow :hidden
@@ -288,4 +293,54 @@
              {:color colour/clickable
               :cursor :pointer}
              [:&:hover
-              {:color colour/clickable-hovered}]]])
+              {:color colour/clickable-hovered}]]
+
+            [:.shared-collapsible-text
+             [:div
+              {:margin-top (px 3)
+               :margin-left (px 2)}
+              [:&.rotate270
+               {:margin-top (px -3)
+                :margin-left (px 3)}]]
+             [:span
+              {:margin-top (px 4)
+               :margin-left (px 1)}
+              [:&.ellipsis
+               {:margin-top (px 2)
+                :margin-left (px -2)}]]
+             [:i
+              {:cursor :pointer}]]
+
+            [:.editable-field
+             {:padding [[(em 1) (px 0) (em 1) (em 1)]]
+              :margin-bottom (em 1)
+              ;;:width (percent 100)
+              :line-height (em 1.7)
+              :border-color colour/subtle-grey
+              :border-radius (px 2)
+              :box-shadow [[(px 0) (px 1) (px 4) "rgba(0,0,0,.14)"]]}
+             [:&:hover
+              {}]
+             [:span.clickable-text.edit-label
+              {:font-size (px 12)
+               :height (em 0.75)
+               :line-height (em 0.75)
+               :position :absolute
+               :right (px 20)}]
+             [:.heading
+              {:margin-top (em 0)}]
+             [:.intro
+              {:line-height (em 1.5)
+               :display :block
+               :font-size (px 11)
+               :color 'dimgrey
+               :margin-bottom (em 1)}]
+
+             [:.editable-field-content
+              {:display :flex
+               :justify-content :space-between
+               :vertical-align :bottom
+               :align-items :flex-end}]]
+
+            [:.editable-field-editing
+             {}]])

--- a/test/cljs/witan/ui/runner.cljs
+++ b/test/cljs/witan/ui/runner.cljs
@@ -8,6 +8,7 @@
            [witan.ui.test.data-test]
            [witan.ui.test.activities-test]
            [witan.ui.test.controllers.datastore-test]
+           [witan.ui.test.components.create-datapack-test]
            ;;
            [witan.ui.route :as route]
            [accountant.core :as accountant]))
@@ -24,4 +25,5 @@
            'witan.ui.test.route-test
            'witan.ui.test.data-test
            'witan.ui.test.activities-test
-           'witan.ui.test.controllers.datastore-test)
+           'witan.ui.test.controllers.datastore-test
+           'witan.ui.test.components.create-datapack-test)

--- a/test/cljs/witan/ui/test/components/create_datapack_test.cljs
+++ b/test/cljs/witan/ui/test/components/create_datapack_test.cljs
@@ -1,0 +1,4 @@
+(ns witan.ui.test.components.create-datapack-test
+  (:require  [cljs.test :refer-macros [deftest is testing]]
+             [witan.ui.test.base :as b]
+             [witan.ui.components.create-datapack :as cdp]))


### PR DESCRIPTION
With this patch you can create datapacks from the 'create datapack' button on the dashboard. There are still some rough edges to the process (for example, lack of a progress indicator whilst we have no uploads to perform) but it's functional.

You can also navigate to datapacks from the dashboard and they will attempt to load in the file view - this needs fixing.
 
Also, this was our final agreement for the sharing column:

![screenshot from 2017-07-13 09-58-04](https://user-images.githubusercontent.com/812199/28158919-383dbe04-67b3-11e7-93c4-6142dc62a60b.png)
![screenshot from 2017-07-13 09-58-20](https://user-images.githubusercontent.com/812199/28158920-384266a2-67b3-11e7-952e-82b6b26455ab.png)
