### PR TITLE
Datapack file sharing changes

### DIFF
--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -118,11 +118,11 @@
 (defn download-file
   [id]
   #(set! (.. js/window -location -href)
-        (str
-         (if (:gateway/secure? data/config) "https://" "http://")
-         (or (:gateway/address data/config) "localhost:30015")
-         "/download?id="
-         id)))
+         (str
+          (if (:gateway/secure? data/config) "https://" "http://")
+          (or (:gateway/address data/config) "localhost:30015")
+          "/download?id="
+          id)))
 
 (defmulti metadata
   (fn [md _]
@@ -186,10 +186,10 @@
 (defn total-bundled-size
   [meta]
   (->> meta
-      :kixi.datastore.metadatastore/bundled-files
-      vals
-      (map :kixi.datastore.metadatastore/size-bytes)
-      (reduce +)))
+       :kixi.datastore.metadatastore/bundled-files
+       vals
+       (map :kixi.datastore.metadatastore/size-bytes)
+       (reduce +)))
 
 (defmethod metadata
   ["bundle" "datapack"]
@@ -243,7 +243,7 @@
                        (shared/button {:icon icons/download
                                        :id (str (:kixi.datastore.metadatastore/id %) "-download")
                                        :prevent? true
-                                       :disabled? (empty? (clojure.set/intersection 
+                                       :disabled? (empty? (clojure.set/intersection
                                                            (set (map :kixi.group/id (get-in % [:kixi.datastore.metadatastore/sharing
                                                                                                :kixi.datastore.metadatastore/file-read])))
                                                            (set (data/get-in-app-state :app/user :kixi.user/groups))))}
@@ -296,7 +296,7 @@
     (shared/button {:icon icons/download
                     :id :download
                     :txt :string/file-actions-download-file
-                    :prevent? true} 
+                    :prevent? true}
                    (download-file current))]])
 
 (defn sharing-detailed
@@ -672,18 +672,6 @@
     (route/swap-query-string! #(assoc % subview-query-param i))
     (reset! subview-tab k)))
 
-(defn user-has-permission?
-  [permission user file-metadata]
-  (let [ug (:kixi.user/groups user)
-        vg (set (map :kixi.group/id (get-in file-metadata [:kixi.datastore.metadatastore/sharing permission])))]
-    (some vg ug)))
-
-(def user-has-edit?
-  (partial user-has-permission? :kixi.datastore.metadatastore/meta-update))
-
-(def user-has-download?
-  (partial user-has-permission? :kixi.datastore.metadatastore/file-read))
-
 (defn md->tab-config
   [md has-edit?]
   (cond
@@ -706,7 +694,6 @@
 
 ;;
 
-
 (defn view
   []
   (reset! subview-tab (idx->tab (or (utils/query-param-int subview-query-param 0 2) 0)))
@@ -716,9 +703,9 @@
             (data/get-in-app-state :app/datastore)
             activities->string (:ds/activities ds)
             md (data/get-in-app-state :app/datastore :ds/file-metadata current)
-            has-edit? (user-has-edit? (data/get-in-app-state :app/user) md)
-            can-download? (user-has-download? (data/get-in-app-state :app/user) md)
             is-bundle? (= "bundle" (:kixi.datastore.metadatastore/type md))
+            has-edit? (utils/user-has-edit? (data/get-in-app-state :app/user) md)
+            can-download? (utils/user-has-download? (data/get-in-app-state :app/user) md)
             remove-new-fn (fn []
                             (route/swap-query-string! (fn [x] (dissoc x :new)))
                             (reset! new? false))

--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -685,7 +685,7 @@
     (= "datapack" (:kixi.datastore.metadatastore/bundle-type md))
     (if has-edit?
       {:overview (get-string :string/overview)
-       :files (get-string :string/files)
+       ;;:files (get-string :string/files)
        :sharing (get-string :string/sharing)
        :edit (get-string :string/edit)}
       {:overview (get-string :string/overview)

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -497,9 +497,7 @@
      {:failed #(gstring/format (get-string :string.activity.update-sharing/failed)
                                (:kixi.datastore.metadatastore/name md))
       :completed #(gstring/format (get-string :string.activity.update-sharing/completed)
-                                  (:kixi.datastore.metadatastore/name md)
-                                  (i/capitalize (:kixi.group/type group))
-                                  (:kixi.group/name group))})))
+                                  (:kixi.datastore.metadatastore/name md))})))
 
 (defmethod handle
   :sharing-add-group
@@ -697,16 +695,12 @@
                       :kixi.comms.event/payload
                       :kixi.datastore.metadatastore/file-metadata
                       :kixi.datastore.metadatastore/bundled-ids])]
-    (log/debug "aaa READ GROUPS" read-groups)
-    (log/debug "aaa FILES" files)
     (run!
      (fn [file-id]
-       (log/debug "bbb doing file" file-id (get-local-file file-id))
        (let [md (get-local-file file-id)]
          (when (utils/user-has-edit? user md)
            (run!
             (fn [gid]
-              (log/debug "bbb doing group" gid)
               (when-not (= gid (:kixi.user/self-group user))
                 (add-group-to-file-sharing {:id file-id
                                             :group {:kixi.group/id gid}}))) read-groups))))

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -268,7 +268,7 @@
    :string.activity.update-metadata/failed      "You failed to update the metadata for file '%s' (%s) - %s"
    :string.activity.update-metadata/completed   "You successfully updated the metadata for file '%s' (%s)"
    :string.activity.update-sharing/failed       "You failed to update the sharing details for file '%s'"
-   :string.activity.update-sharing/completed    "You successfully updated the sharing details for file '%s' (%s: %s)"
+   :string.activity.update-sharing/completed    "You successfully updated the sharing details for file '%s'"
    :string.activity.create-datapack/failed      "You failed to create the datapack '%s'"
    :string.activity.create-datapack/completed   "You successfully created the datapack '%s'"
    })

--- a/src/cljs/witan/ui/utils.cljs
+++ b/src/cljs/witan/ui/utils.cljs
@@ -58,3 +58,15 @@
          (dissoc a k)
          a)) m m)
     m))
+
+(defn user-has-permission?
+  [permission user file-metadata]
+  (let [ug (:kixi.user/groups user)
+        vg (set (map :kixi.group/id (get-in file-metadata [:kixi.datastore.metadatastore/sharing permission])))]
+    (some vg ug)))
+
+(def user-has-edit?
+  (partial user-has-permission? :kixi.datastore.metadatastore/meta-update))
+
+(def user-has-download?
+  (partial user-has-permission? :kixi.datastore.metadatastore/file-read))

--- a/src/styles/witan/ui/style/shared.clj
+++ b/src/styles/witan/ui/style/shared.clj
@@ -27,7 +27,10 @@
              [:th
               {:color colour/table-header-text
                :font-weight :normal
-               :cursor :default}]
+               :cursor :default}
+              [:&:first-child
+               {:border-bottom 0
+                :display :inline-block}]]
              [:tbody
               [:tr
                {:transition (transition :background-color "0.15s"


### PR DESCRIPTION
This adds cascading sharing permissions onto datapack participants once a datapack is created -- NOT when users are added to a datapack