### PR TITLE
Correct indentation to avoid saving error data

### DIFF
--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -61,10 +61,11 @@
 
 (defn save-file-metadata!
   [{:keys [kixi.datastore.metadatastore/id] :as payload}]
-  (log/debug "Saving file metadata..." id)
-  (data/swap-app-state! :app/datastore assoc-in [:ds/file-metadata id] payload)
-  (when (= id (data/get-in-app-state :app/datastore :ds/file-metadata-editing :kixi.datastore.metadatastore/id))
-    (reset-file-edit-metadata! payload)))
+  (when id
+    (log/debug "Saving file metadata..." id)
+    (data/swap-app-state! :app/datastore assoc-in [:ds/file-metadata id] payload)
+    (when (= id (data/get-in-app-state :app/datastore :ds/file-metadata-editing :kixi.datastore.metadatastore/id))
+      (reset-file-edit-metadata! payload))))
 
 (defn selected-groups->sharing-activities
   [groups activities]

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -228,11 +228,11 @@
         (do
           (log/warn "File" id "is not accessible.")
           (data/swap-app-state! :app/datastore assoc :ds/error :string/file-inaccessible)
-          (data/swap-app-state! :app/datastore assoc :ds/query-tries 0)))))
-  (do
-    (data/swap-app-state! :app/datastore assoc :ds/query-tries 0)
-    (save-file-metadata! data)
-    (set-title! (:kixi.datastore.metadatastore/name data))))
+          (data/swap-app-state! :app/datastore assoc :ds/query-tries 0))))
+    (do
+      (data/swap-app-state! :app/datastore assoc :ds/query-tries 0)
+      (save-file-metadata! data)
+      (set-title! (:kixi.datastore.metadatastore/name data)))))
 
 (defmethod on-query-response
   :error


### PR DESCRIPTION
I strongly suspect that the lower 'do' was accidentally slurped outside
of the 'if' which meant the code was trying to save erroneous metadata.