### PR TITLE
Aggressive replacement was losing fields introduced by other services

### DIFF
--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -210,7 +210,7 @@
                         :items items
                         :paging paging)
   (doseq [{:keys [kixi.datastore.metadatastore/id] :as payload} items]
-    (data/swap-app-state! :app/datastore assoc-in [:ds/file-metadata id] payload)))
+    (data/swap-app-state! :app/datastore update-in [:ds/file-metadata id] #(merge % payload))))
 
 
 (defmethod on-query-response


### PR DESCRIPTION
Using `update -> merge` rather than `assoc` should preserve these
other fields.