### PR TITLE
Add panic topic to push exceptions to Intercom.

### DIFF
--- a/src/cljs/witan/ui/activities.cljs
+++ b/src/cljs/witan/ui/activities.cljs
@@ -169,13 +169,7 @@
   (let [{:keys [activity] :as app-state}
         (data/get-in-app-state :app/activities :activities/pending id)]
     (when (and app-state (= activity-name activity))
-      ;; FIXME - Change message to something useful from a reporter.
-      (do
-        (data/publish-topic :activity/panic {:message "something"
-                                             :activity activity
-                                             :activity-name activity-name
-                                             :id id})
-        (finish-activity! nil :failed id)))))
+      (finish-activity! nil :failed id))))
 
 (defn process-event
   [{:keys [args]}]

--- a/src/cljs/witan/ui/activities.cljs
+++ b/src/cljs/witan/ui/activities.cljs
@@ -169,7 +169,13 @@
   (let [{:keys [activity] :as app-state}
         (data/get-in-app-state :app/activities :activities/pending id)]
     (when (and app-state (= activity-name activity))
-      (finish-activity! nil :failed id))))
+      ;; FIXME - Change message to something useful from a reporter.
+      (do
+        (data/publish-topic :activity/panic {:message "something"
+                                             :activity activity
+                                             :activity-name activity-name
+                                             :id id})
+        (finish-activity! nil :failed id)))))
 
 (defn process-event
   [{:keys [args]}]

--- a/src/cljs/witan/ui/controllers/intercom.cljs
+++ b/src/cljs/witan/ui/controllers/intercom.cljs
@@ -21,27 +21,39 @@
                          :widget {:activator "#IntercomDefaultWidget"}}))
     (.setInterval js/window do-update (* 1000 60 4))))
 
+(defn parse-payload [payload message]
+  (-> payload
+      (dissoc :message)
+      (assoc :message-type (or (:kixi.comms.message/type message)
+                               (:kixi.message/type message)
+                               "Unknown"))
+      (assoc :message-key  (str (or (:kixi.comms.event/key message)
+                                    (:kixi.event/type message)
+                                    (:kixi.comms.command/key message)
+                                    (:kixi.command/type message)
+                                    "n/a")))
+      (assoc :message-id   (or (:kixi.comms.event/id message)
+                               (:kixi.event/id message)
+                               (:kixi.comms.command/id message)
+                               (:kixi.command/id message)
+                               "n/a"))))
+
+
+(defn publish-to-intercom [event-label name activity payload message]
+  (.Intercom js/window
+             event-label
+             (name activity)
+             (clj->js (parse-payload payload message))))
+
+(defn on-panic-event
+  [{:keys [args]}]
+  (let [{:keys [activity message] :as payload} args]
+    (publish-to-intercom "panicEvent" name activity payload message)))
+
 (defn on-activity-finished
   [{:keys [args]}]
   (let [{:keys [activity message] :as payload} args]
-    (.Intercom js/window
-               "trackEvent"
-               (name activity)
-               (clj->js (-> payload
-                            (dissoc :message)
-                            (assoc :message-type (or (:kixi.comms.message/type message)
-                                                     (:kixi.message/type message)
-                                                     "Unknown"))
-                            (assoc :message-key  (str (or (:kixi.comms.event/key message)
-                                                          (:kixi.event/type message)
-                                                          (:kixi.comms.command/key message)
-                                                          (:kixi.command/type message)
-                                                          "n/a")))
-                            (assoc :message-id   (or (:kixi.comms.event/id message)
-                                                     (:kixi.event/id message)
-                                                     (:kixi.comms.command/id message)
-                                                     (:kixi.command/id message)
-                                                     "n/a")))))))
+    (publish-to-intercom "trackEvent" name activity payload message)))
 
 (defmulti handle
   (fn [event args] event))
@@ -54,4 +66,5 @@
 (defonce subscriptions
   (when (cljs-env :intercom)
     (data/subscribe-topic :data/user-logged-in on-user-logged-in)
-    (data/subscribe-topic :activity/activity-finished on-activity-finished)))
+    (data/subscribe-topic :activity/activity-finished on-activity-finished)
+    (data/subscribe-topic :data/panic-event-triggered on-panic-event)))

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -136,20 +136,6 @@
    (keys user-map)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Panic
-
-(defn panic!
-  [msg]
-  (log/severe "App has panicked:" msg)
-  ;; FIXME HERE
-  (publish-topic :data/panic-event-triggered msg)
-  (reset-app-state! :app/panic-message msg))
-
-(.addEventListener js/window "error"
-                   (fn [e]
-                     (panic! (.. e -error -message))))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; PubSub
 
 (def publisher (chan))
@@ -176,6 +162,19 @@
   (let [subscriber (chan)
         _ (sub publication topic subscriber)]
     (go (cb (<! subscriber)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Panic
+
+(defn panic!
+  [msg]
+  (log/severe "App has panicked:" msg)
+  (publish-topic :data/panic {:message msg})
+  (reset-app-state! :app/panic-message msg))
+
+(.addEventListener js/window "error"
+                   (fn [e]
+                     (panic! (.. e -error -message))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Cookies

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -141,6 +141,8 @@
 (defn panic!
   [msg]
   (log/severe "App has panicked:" msg)
+  ;; FIXME HERE
+  (publish-topic :data/panic-event-triggered msg)
   (reset-app-state! :app/panic-message msg))
 
 (.addEventListener js/window "error"


### PR DESCRIPTION
Branch development PR: 

Added topic to push panic exceptions through to Intercom for inspection. For example in the local testing 

`{:topic :activity/panic, :args {:message "something", :activity :upload-file, :activity-name :upload-file, :id "edb1fb66-0945-4dd7-b9b4-01d2300e4695"}}`

Current WIP commit is for the basic structure of the panic alert and some refactoring of the original intercom.cljs code. The function `abandon-activity!` in activities.cljs needs to pull a reporter for more info. This still needs fixing. 