### PR TITLE
Bug: Header querying is not case insensitive which leads to null values.

### DIFF
--- a/src/cljs/witan/ui/ajax.cljs
+++ b/src/cljs/witan/ui/ajax.cljs
@@ -17,13 +17,13 @@
 
 (defn- request
   [method-fn {:keys [id params result-cb auth suppress-error?]}]
-  (method-fn {:params params
-              :handler (partial handle-response :success id result-cb)
-              :error-handler (when-not suppress-error? (partial handle-response :failure id result-cb))
-              :format :transit
+  (method-fn {:params          params
+              :handler         (partial handle-response :success id result-cb)
+              :error-handler   (when-not suppress-error? (partial handle-response :failure id result-cb))
+              :format          :transit
               :response-format :transit
-              :keywords? true
-              :headers auth}))
+              :keywords?       true
+              :headers         auth}))
 
 (defn GET
   [method {:keys [params] :as args}]
@@ -41,14 +41,16 @@
 
 (defn get-headers
   [response]
-  (ajax.protocols/-get-all-headers response))
+  (as-> (ajax.protocols/-get-all-headers response) h
+    (reduce-kv (fn [a k v] (assoc a (clojure.string/lower-case k) v)) {} h)
+    (update h "vary" #(when % (clojure.string/lower-case %)))))
 
 (defn s3-upload [uri {:keys [params] :as args}]
   (log/debug "PUT" uri params)
   (ajax/ajax-request
    (merge
-    {:uri uri
-     :method :put
-     :format (ajax/text-request-format)
+    {:uri             uri
+     :method          :put
+     :format          (ajax/text-request-format)
      :response-format {:read get-headers :description "headers"}}
     args)))

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -773,9 +773,10 @@
                                                                         {:message :string/uploading
                                                                          :progress upload-frac}))
                              :handler (fn [[ok resp]]
-                                        (if ok
-                                          (put! result-chan (get resp "etag"))
-                                          (put! result-chan (if (pos? retries) :retry false))))})
+                                        (let [etag (get resp "etag")]
+                                          (if (and ok etag)
+                                            (put! result-chan etag)
+                                            (put! result-chan (if (pos? retries) :retry false)))))})
             (let [result (<! result-chan)]
               (cond
                 ;;


### PR DESCRIPTION
For some reason headers returned by Chrome are lower-cased, whereas headers returned by Edge and IE11 are not. There was a naive `get` which caused a null value in the latter browsers which caused a panic.