### PR TITLE
Remove paging when we're filtering the metadata type

### DIFF
--- a/src/cljs/witan/ui/components/dashboard/data.cljs
+++ b/src/cljs/witan/ui/components/dashboard/data.cljs
@@ -90,12 +90,16 @@
                            :on-double-click navigate-fn})
             (when datasets
               [:div.flex-center.dash-pagination
-               [shared/pagination {:page-blocks
-                                   (range 1 (inc (.ceil js/Math (/ (get-in raw-data [:paging :total])
-                                                                   (data/get-in-app-state :app/datastore :ds/page-size)))))
-                                   :current-page local-current-page}
-                (fn [id]
-                  (let [new-page (js/parseInt (subs id 5))]
-                    (reset! local-current-page new-page)
-                    (route/swap-query-string! #(assoc % dash-page-query-param new-page))
-                    (controller/raise! :data/set-current-page {:page new-page})))]])]]))})))
+               (if file-type-filter
+                 [:span.clickable-text
+                  {:on-click #(route/navigate! :app/data-dash {})}
+                  (get-string :string/dash-reanable-paging)]
+                 [shared/pagination {:page-blocks
+                                     (range 1 (inc (.ceil js/Math (/ (get-in raw-data [:paging :total])
+                                                                     (data/get-in-app-state :app/datastore :ds/page-size)))))
+                                     :current-page local-current-page}
+                  (fn [id]
+                    (let [new-page (js/parseInt (subs id 5))]
+                      (reset! local-current-page new-page)
+                      (route/swap-query-string! #(assoc % dash-page-query-param new-page))
+                      (controller/raise! :data/set-current-page {:page new-page})))])])]]))})))

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -290,6 +290,7 @@
    :string/meta-image-url-placeholder       "Provide a logo image as a URL e.g. https://mydomain.com/mylogo.png"
    :string/invalid-url                      "Invalid URL"
    :string/supports                         "Supports"
+   :string/dash-reanable-paging             "To enable paging, please return to the unfiltered dashboard"
    ;;
    :string.about/contact-us-1                "If you need Witan support, please either use our live help system or email us at"
    :string.about/contact-us-2                "For all other enquiries, please email us at"


### PR DESCRIPTION
**Remove paging when we're filtering the metadata type**
This is a compromise solution to working around the problem of Datastore
not filtering for us (which breaks paging). We will re-look at this
problem once search is available.