### PR TITLE
Move page number into the app state

### DIFF
--- a/src/cljs/witan/ui/components/dashboard/data.cljs
+++ b/src/cljs/witan/ui/components/dashboard/data.cljs
@@ -34,16 +34,17 @@
 
 (defn view
   []
-  (let [selected-id (r/atom nil)
-        local-current-page (r/atom (or (utils/query-param-int dash-page-query-param 1 999) 1))]
+  (let [selected-id (r/atom nil)]
     (r/create-class
      {:component-did-mount
       (fn [this]
-        (when-not (= 1 @local-current-page)
-          (controller/raise! :data/set-current-page {:page @local-current-page})))
+        (controller/raise!
+         :data/set-current-page
+         {:page (or (utils/query-param-int dash-page-query-param 1 999) 1)}))
       :reagent-render
       (fn []
         (let [raw-data (data/get-app-state :app/data-dash)
+              current-page (data/get-in-app-state :app/data-dash :dd/current-page)
               file-type-filter (:dd/file-type-filter raw-data)
               buttons [{:id :datapack :icon icons/datapack :txt :string/create-new-datapack :class "data-upload"}
                        {:id :upload :icon icons/upload :txt :string/upload-new-data :class "data-upload"}]
@@ -97,9 +98,8 @@
                  [shared/pagination {:page-blocks
                                      (range 1 (inc (.ceil js/Math (/ (get-in raw-data [:paging :total])
                                                                      (data/get-in-app-state :app/datastore :ds/page-size)))))
-                                     :current-page local-current-page}
+                                     :current-page current-page}
                   (fn [id]
                     (let [new-page (js/parseInt (subs id 5))]
-                      (reset! local-current-page new-page)
                       (route/swap-query-string! #(assoc % dash-page-query-param new-page))
                       (controller/raise! :data/set-current-page {:page new-page})))])])]]))})))

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -81,7 +81,7 @@
                     :workspace/running? false
                     :workspace/pending? true}
     :app/workspace-dash {:wd/workspaces nil}
-    :app/data-dash {}
+    :app/data-dash {:dd/current-page 1}
     :app/create-data {:cd/pending? false}
     :app/create-datapack {:cdp/pending? false}
     :app/rts-dash {}
@@ -190,6 +190,7 @@
    (swap-app-state! :app/workspace assoc :workspace/pending? true)
    (swap-app-state! :app/workspace dissoc :workspace/current)
    (reset-app-state! :app/panic-message nil)
+   (reset-app-state! :app/route nil)
    (swap-app-state! :app/create-data dissoc :cd/pending-data)
    (swap-app-state! :app/user dissoc :user/group-search-results)
    (swap-app-state! :app/user dissoc :user/group-search-filtered)

--- a/src/cljs/witan/ui/route.cljs
+++ b/src/cljs/witan/ui/route.cljs
@@ -65,10 +65,11 @@
              m {:route/path handler
                 :route/params route-params
                 :route/address path
-                :route/query (query-string->map)}]
+                :route/query (query-string->map)}
+             prev (data/get-app-state :app/route)]
          (log/debug "Dispatching to route:" path "=>" handler)
          (data/reset-app-state! :app/route m)
-         (data/publish-topic :data/route-changed m)
+         (data/publish-topic :data/route-changed (assoc m :route/previous prev))
          (put! app-route-chan handler))
        (log/severe "Couldn't match a route to this path:" path)))))
 

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -80,6 +80,7 @@
                     (s/optional-key :workspace/model-list) [{s/Keyword s/Any}]}
    :app/workspace-dash {:wd/workspaces (s/maybe [s/Any])}
    :app/data-dash {(s/optional-key :dd/file-type-filter) s/Keyword
+                   :dd/current-page s/Num
                    s/Keyword s/Any}
    :app/create-data {:cd/pending? s/Bool
                      (s/optional-key :cd/error) s/Keyword


### PR DESCRIPTION
**Move page number into the app state**
As is usually the case, putting it into the app state is the most useful
place for this data when it comes to manipulating it via outside
influences. There were a couple of glitches when switching between
filters which made it difficult to reset the page number. Of course,
once it's all controlled in app state it becomes trivial.