### PR TITLE
Moved the activities out of the app-state

### DIFF
--- a/src/cljs/witan/ui/components/create_data.cljs
+++ b/src/cljs/witan/ui/components/create_data.cljs
@@ -72,8 +72,8 @@
 
 (defn view
   [this]
-  (let [activities->string (data/get-in-app-state :app/datastore :ds/activities)
-        locked-activities (data/get-in-app-state :app/datastore :ds/locked-activities)
+  (let [activities->string data/datastore-file-activities
+        locked-activities data/datastore-file-default-activity-permissions
         form-data (r/atom (empty-form-data
                            activities->string
                            locked-activities))]

--- a/src/cljs/witan/ui/components/create_datapack.cljs
+++ b/src/cljs/witan/ui/components/create_datapack.cljs
@@ -145,8 +145,8 @@
 
 (defn view
   []
-  (let [activities->string (data/get-in-app-state :app/datastore :dp/activities)
-        locked-activities (data/get-in-app-state :app/datastore :dp/locked-activities)
+  (let [activities->string data/datastore-bundle-activities
+        locked-activities data/datastore-bundle-default-activity-permissions
         datapack (r/atom (empty-form-data
                           activities->string
                           locked-activities))]

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -600,7 +600,7 @@
                      :kixi.datastore.metadatastore/bundled-ids (set (map :kixi.datastore.metadatastore/id (:selected-files datapack)))
                      :kixi.datastore.metadatastore/sharing (selected-groups->sharing-activities
                                                             (:selected-groups datapack)
-                                                            (keys (data/get-in-app-state :app/datastore :dp/activities)))
+                                                            (keys data/datastore-bundle-activities))
                      :kixi.datastore.metadatastore/provenance {:kixi.datastore.metadatastore/source "upload"
                                                                :kixi.user/id (data/get-in-app-state :app/user :kixi.user/id)}})
      {:failed #(gstring/format (get-string :string.activity.create-datapack/failed) title)
@@ -742,7 +742,7 @@
                                    :kixi.datastore.metadatastore/file-type ext
                                    :kixi.datastore.metadatastore/sharing (selected-groups->sharing-activities
                                                                           selected-groups
-                                                                          (keys (data/get-in-app-state :app/datastore :ds/activities)))
+                                                                          (keys data/datastore-file-activities))
                                    :kixi.datastore.metadatastore/provenance {:kixi.datastore.metadatastore/source "upload"
                                                                              :kixi.user/id user-id}
                                    :kixi.datastore.metadatastore/size-bytes (.-size pending-file)

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -62,6 +62,26 @@
    :kixi.user/groups [nil]
    :kixi.user/self-group nil})
 
+;; statics
+(def datastore-file-activities
+  {:kixi.datastore.metadatastore/meta-read (get-string :string/file-sharing-meta-read)
+   :kixi.datastore.metadatastore/meta-update (get-string :string/file-sharing-meta-update)
+   :kixi.datastore.metadatastore/file-read (get-string :string/file-sharing-file-read)})
+
+(def datastore-file-default-activity-permissions
+  [:kixi.datastore.metadatastore/meta-update
+   :kixi.datastore.metadatastore/meta-read])
+
+(def datastore-bundle-activities
+  {:kixi.datastore.metadatastore/meta-read (get-string :string/file-sharing-meta-read)
+   :kixi.datastore.metadatastore/meta-update (get-string :string/file-sharing-meta-update)
+   :kixi.datastore.metadatastore/bundle-add (get-string :string/datapack-sharing-bundle-add)})
+
+(def datastore-bundle-default-activity-permissions
+  [:kixi.datastore.metadatastore/meta-update
+   :kixi.datastore.metadatastore/meta-read
+   :kixi.datastore.metadatastore/bundle-add])
+
 ;; default app-state
 (defonce app-state
   (->>
@@ -100,18 +120,7 @@
                     :ds/file-properties {}
                     :ds/page-size 20
                     :ds/query-tries 0
-                    :ds/data-view-subview-idx 0
-                    :ds/activities {:kixi.datastore.metadatastore/meta-read (get-string :string/file-sharing-meta-read)
-                                    :kixi.datastore.metadatastore/meta-update (get-string :string/file-sharing-meta-update)
-                                    :kixi.datastore.metadatastore/file-read (get-string :string/file-sharing-file-read)}
-                    :ds/locked-activities [:kixi.datastore.metadatastore/meta-update
-                                           :kixi.datastore.metadatastore/meta-read]
-                    :dp/activities {:kixi.datastore.metadatastore/meta-read (get-string :string/file-sharing-meta-read)
-                                    :kixi.datastore.metadatastore/meta-update (get-string :string/file-sharing-meta-update)
-                                    :kixi.datastore.metadatastore/bundle-add (get-string :string/datapack-sharing-bundle-add)}
-                    :dp/locked-activities [:kixi.datastore.metadatastore/meta-update
-                                           :kixi.datastore.metadatastore/meta-read
-                                           :kixi.datastore.metadatastore/bundle-add]}
+                    :ds/data-view-subview-idx 0}
     :app/activities {:activities/log []
                      :activities/pending {}}}
    (s/validate ws/AppStateSchema)

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -107,11 +107,7 @@
                    :ds/file-metadata-editing s/Any ;; TODO: metadata schema
                    :ds/file-metadata-editing-command s/Any ;; TODO: metadata schema + updates
                    :ds/file-properties FilePropertiesSchema
-                   :ds/activities {s/Keyword s/Str}
                    :ds/page-size s/Num
-                   :ds/locked-activities [s/Keyword]
-                   :dp/activities {s/Keyword s/Str}
-                   :dp/locked-activities [s/Keyword]
                    :ds/query-tries s/Num
                    :ds/data-view-subview-idx s/Num
                    (s/optional-key :ds/files-search-filtered) [s/Any]

--- a/src/styles/witan/ui/style/shared.clj
+++ b/src/styles/witan/ui/style/shared.clj
@@ -199,7 +199,8 @@
              [:i
               {:padding-right (em 0.5)}]
              [:.message
-              {:overflow :hidden}]]
+              {:overflow :hidden
+               :line-height (em 1.4)}]]
 
 
 ;;;;;;;;;;;;;;


### PR DESCRIPTION
**Moved the activities out of the app-state**
Being in the app-state meant they were being cached locally and
therefore not updated when changed (cache used instead of empty
app-state). This lead to them not appearing in matrices or being sent
with bundle perms to datastore.