### PR TITLE
Parsing page arg to int on route change

### DIFF
--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -204,7 +204,7 @@
       (data/swap-app-state! :app/data-dash assoc :dd/file-type-filter type-filter)
       (data/swap-app-state! :app/data-dash dissoc :dd/file-type-filter))
     (data/swap-app-state! :app/data-dash assoc :dd/current-page
-                          (or (get-in args [:route/query dash-page-query-param]) 1)))
+                          (or (js/parseInt (get-in args [:route/query dash-page-query-param])) 1)))
   (send-dashboard-query!)
   (set-title! (get-string :string/title-data-dashboard)))
 


### PR DESCRIPTION
Error reported from ui:

Value does not match schema: {:app/data-dash
{:dd/current-page (not (instance? #object[Number "function Number() {
[native code] }"] "3"))}}

Grepping the code it looks like there is a missing parseInt here to
cast the page number back out of the query args.