### PR TITLE
Fix paging parser

### DIFF
--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -204,7 +204,7 @@
       (data/swap-app-state! :app/data-dash assoc :dd/file-type-filter type-filter)
       (data/swap-app-state! :app/data-dash dissoc :dd/file-type-filter))
     (data/swap-app-state! :app/data-dash assoc :dd/current-page
-                          (or (js/parseInt (get-in args [:route/query dash-page-query-param])) 1)))
+                          (js/parseInt (or (get-in args [:route/query dash-page-query-param]) "1"))))
   (send-dashboard-query!)
   (set-title! (get-string :string/title-data-dashboard)))
 


### PR DESCRIPTION
The js parseInt return NaN for a non-numeric or null value, raising
the parsing up so the or can nil pun to the hard coded "1".