### PR TITLE
Making search-term optional

### DIFF
--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -93,7 +93,7 @@
                                                           :paging {:total s/Num
                                                                    :count s/Num
                                                                    :index s/Num}}}}
-                :ks/datapack-files {:ks/current-search s/Str
+                :ks/datapack-files {:ks/current-search (s/maybe s/Str)
                                     :ks/search->result {s/Str {:search-term s/Str
                                                                :items [ListDisplayItem]
                                                                :paging {:total s/Num


### PR DESCRIPTION
The init function for the search component sets this value to nil, but
these causes a schema failure and app crash. This change should allow
the nil value.