### PR TITLE
Files already present in datapacks now have add button disabled

### DIFF
--- a/src/cljs/witan/ui/components/create_datapack.cljs
+++ b/src/cljs/witan/ui/components/create_datapack.cljs
@@ -54,7 +54,8 @@
   [datapack]
   (let [table-id "create-datapack-files-table"
         select-fn (fn [{:keys [kixi.datastore.metadatastore/id] :as x} & _]
-                    (swap! datapack update :selected-files conj x))]
+                    (swap! datapack update :selected-files conj x))
+        present-files (into #{} (map :kixi.datastore.metadatastore/id (:selected-files @datapack)))]
     [editable-field
      nil
      [:div.datapack-edit-file
@@ -72,7 +73,8 @@
         :table-headers-fn (fn []
                             [{:content-fn #(shared/button {:icon icons/tick
                                                            :id (str (:kixi.datastore.metadatastore/id %) "-select")
-                                                           :prevent? true}
+                                                           :prevent? true
+                                                           :disabled? (present-files (:kixi.datastore.metadatastore/id %))}
                                                           identity)
                               :title ""  :weight "50px"}
                              {:content-fn #(shared/inline-file-title % :small :small)
@@ -89,8 +91,7 @@
                                            :kixi.datastore.metadatastore/created
                                            :kixi.datastore.metadatastore/provenance)
                               :title (get-string :string/file-uploaded-at)
-                              :weight 0.20}])}
-       {:exclusions (:selected-files @datapack)}]
+                              :weight 0.20}])}]
       (when (empty? (:selected-files @datapack))
         [:i [:h4 (get-string :string/create-datapack-no-files)]])
       [:div

--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -753,7 +753,8 @@
   (let []
     (fn [{:keys [kixi.datastore.metadatastore/bundled-files]}]
       (let [invisible-files (filter :error (vals bundled-files))
-            visible-files (remove :error (vals bundled-files))]
+            visible-files (remove :error (vals bundled-files))
+            present-files (into #{} (map :kixi.datastore.metadatastore/id (vals bundled-files)))]
         [editable-field
          nil
          [:div.datapack-edit-files
@@ -772,7 +773,8 @@
             :table-headers-fn (fn []
                                 [{:content-fn #(shared/button {:icon icons/tick
                                                                :id (str (:kixi.datastore.metadatastore/id %) "-select")
-                                                               :prevent? true}
+                                                               :prevent? true
+                                                               :disabled? (present-files (:kixi.datastore.metadatastore/id %))}
                                                               identity)
                                   :title ""  :weight 0.10}
                                  {:content-fn #(shared/inline-file-title % :small :small)
@@ -789,8 +791,7 @@
                                                :kixi.datastore.metadatastore/created
                                                :kixi.datastore.metadatastore/provenance)
                                   :title (get-string :string/file-uploaded-at)
-                                  :weight 0.20}])}
-           {:exclusions visible-files}]
+                                  :weight 0.20}])}]
           (if-not (empty? visible-files)
             [shared/table
              {:headers [{:content-fn


### PR DESCRIPTION
Previously files already present in datapacks where being filtered out
of the search results. This changes instead disables the add buttons
for already present files.