### PR TITLE
Decrease the tolerance of scroll in file search

### DIFF
--- a/src/cljs/witan/ui/components/shared.cljs
+++ b/src/cljs/witan/ui/components/shared.cljs
@@ -342,7 +342,7 @@
                   :selected?-fn #(= (selector-key %) (selector-key @selected-group))
                   :on-select (partial select-fn true)
                   :on-double-click (partial select-fn true)
-                  :on-scroll #(if (> % 1.0)
+                  :on-scroll #(if (>= % 0.75)
                                 (on-scroll %))})
           [:div.close
            {:on-click close-fn}


### PR DESCRIPTION
1.0 -> 0.75. Should mean the `on-scroll` predicate is hit sooner