### PR TITLE
Fix an app crash when creating datapacks and uploading files

### DIFF
--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -133,16 +133,6 @@
   (fn [[k v]] k))
 
 (defmethod on-query-response
-  :datastore/metadata-with-activities
-  [[_ {:keys [items paging]}]]
-  (reset! dash-query-pending? false)
-  (data/swap-app-state! :app/data-dash assoc
-                        :items items
-                        :paging paging)
-  (doseq [{:keys [kixi.datastore.metadatastore/id] :as payload} items]
-    (data/swap-app-state! :app/datastore update-in [:ds/file-metadata id] #(merge % payload))))
-
-(defmethod on-query-response
   :datastore/metadata-by-id
   [[_ data]]
   (if (:error data)

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -236,7 +236,7 @@
 (defmethod on-metadata-updated
   :kixi.datastore.communication-specs/file-metadata-created
   [args]
-  (add-new-metadata-to-app-state! (get-in args [:kixi.datastore.metadatastore/file-metadata])))
+  #_(add-new-metadata-to-app-state! (get-in args [:kixi.datastore.metadatastore/file-metadata])))
 
 (defmethod on-metadata-updated
   :kixi.datastore.communication-specs/file-metadata-sharing-updated

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -37,17 +37,6 @@
            [:id :name]}
           :kixi.data-acquisition.request-for-data/message]})
 
-(defn add-new-metadata-to-app-state!
-  [md]
-  (let [new-id (:kixi.datastore.metadatastore/id md)
-        new-meta (assoc-in md
-                           [:kixi.datastore.metadatastore/provenance :kixi/user] (data/get-user))
-        existing (some #(when (= (:kixi.datastore.metadatastore/id %) new-id) %)
-                       (data/get-in-app-state :app/data-dash :items))]
-    (when-not existing
-      (data/swap-app-state! :app/data-dash update :items #(cons new-meta %))
-      (data/swap-app-state! :app/datastore update :ds/file-metadata #(assoc % new-id new-meta)))))
-
 ;; Bundle add to datapack via collect and share: message and pending components.
 (defn reset-bundle-add-messages
   []
@@ -235,8 +224,7 @@
 
 (defmethod on-metadata-updated
   :kixi.datastore.communication-specs/file-metadata-created
-  [args]
-  #_(add-new-metadata-to-app-state! (get-in args [:kixi.datastore.metadatastore/file-metadata])))
+  [args])
 
 (defmethod on-metadata-updated
   :kixi.datastore.communication-specs/file-metadata-sharing-updated
@@ -546,9 +534,7 @@
 
 (defn remove-deleted-file!
   [id]
-  (data/swap-app-state! :app/datastore update :ds/file-metadata dissoc id)
-  (data/swap-app-state! :app/data-dash update :items (fn [items]
-                                                       (vec (remove #(= id (:kixi.datastore.metadatastore/id %)) items)))))
+  (data/swap-app-state! :app/datastore update :ds/file-metadata dissoc id))
 
 (defmethod handle
   :delete-file
@@ -848,8 +834,6 @@
                       [:kixi.datastore.metadatastore/meta-read
                        :kixi.datastore.metadatastore/file-read]))) read-groups))))
      files))
-
-  #_(add-new-metadata-to-app-state! (get-in args [:message :kixi.comms.event/payload :kixi.datastore.metadatastore/file-metadata]))
 
   (js/setTimeout
    #(do

--- a/src/cljs/witan/ui/controllers/datastore.cljs
+++ b/src/cljs/witan/ui/controllers/datastore.cljs
@@ -849,7 +849,7 @@
                        :kixi.datastore.metadatastore/file-read]))) read-groups))))
      files))
 
-  (add-new-metadata-to-app-state! (get-in args [:message :kixi.comms.event/payload :kixi.datastore.metadatastore/file-metadata]))
+  #_(add-new-metadata-to-app-state! (get-in args [:message :kixi.comms.event/payload :kixi.datastore.metadatastore/file-metadata]))
 
   (js/setTimeout
    #(do

--- a/src/cljs/witan/ui/controllers/search.cljs
+++ b/src/cljs/witan/ui/controllers/search.cljs
@@ -195,6 +195,7 @@
   :app/data-dash
   [{:keys [args]}]
   (let [query-params (:route/query args)]
+    (data/swap-app-state-in! [:app/search :ks/dashboard] assoc :ks/search->result {})
     (handle :dashboard query-params)
     (set-title! (get-string :string/title-data-dashboard))))
 

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -100,11 +100,11 @@
                                                                     :count s/Num
                                                                     :index s/Num}}}}
                 :ks/datapack-files {:ks/current-search Search
-                                    :ks/search->result {s/Str {:search Search
-                                                               :items [ListDisplayItem]
-                                                               :paging {:total s/Num
-                                                                        :count s/Num
-                                                                        :index s/Num}}}}
+                                    :ks/search->result {Search {:search Search
+                                                                :items [ListDisplayItem]
+                                                                :paging {:total s/Num
+                                                                         :count s/Num
+                                                                         :index s/Num}}}}
                 :ks/datapack-files-expand-in-progress s/Bool}
 
    :app/create-data {:cd/pending? s/Bool


### PR DESCRIPTION
* Datapack search schema was wrong; caused exception when saving (invalid schema)
* Deleted app-state atom was referenced; caused NPE