### PR TITLE
Add facilities required for collect and share v1

### DIFF
--- a/src/cljs/witan/ui/activities.cljs
+++ b/src/cljs/witan/ui/activities.cljs
@@ -89,7 +89,20 @@
    :send-collect-request [{:kixi.command/type :kixi.collect/request-collection}
                           (a/or
                            [{:kixi.event/type :kixi.collect/collection-requested} (a/$ :completed)]
-                           [{:kixi.event/type :kixi.collect/collection-request-rejected} (a/$ :failed)])]})
+                           [{:kixi.event/type :kixi.collect/collection-request-rejected} (a/$ :failed)])]
+   :submit-to-collection [{:kixi.command/type :kixi.datastore/add-files-to-bundle}
+                          (a/or
+                           {:kixi.event/type :kixi.datastore/files-added-to-bundle}
+                           [{:kixi.event/type :kixi.datastore/files-add-to-bundle-rejected} (a/$ :failed)])
+                          ;; TODO move this to process manager
+                          {:kixi.command/type :kixi.datastore/sharing-change} ;; meta-read
+                          (a/or
+                           [{:kixi.event/type  :kixi.datastore/sharing-changed} (a/$ :completed)]
+                           [{:kixi.event/type  :kixi.datastore/sharing-change-rejected} (a/$ :failed)])
+                          {:kixi.command/type :kixi.datastore/sharing-change} ;; file-read
+                          (a/or
+                           [{:kixi.event/type  :kixi.datastore/sharing-changed} (a/$ :completed)]
+                           [{:kixi.event/type  :kixi.datastore/sharing-change-rejected} (a/$ :failed)])]})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cljs/witan/ui/components/bundle_add.cljs
+++ b/src/cljs/witan/ui/components/bundle_add.cljs
@@ -31,7 +31,8 @@
           [:h2.heading (get-string :string/files)]
           [shared/file-search-area
            {:ph :string/edit-datapack-search-files
-            :on-click #(swap! files conj %)
+            ;;:on-click #(swap! files conj %)
+            :on-click #(reset! files #{%}) ;; HACK only one file allowed at the moment
             :on-init #(controller/raise! :search/clear-datapack-files {})
             :on-scroll #(controller/raise! :search/datapack-files-expand {})
             :on-search #(controller/raise! :search/datapack-files {:search-term %})
@@ -90,24 +91,29 @@
                         ]
               :content @files}])]]))))
 
-
 (defn view
   []
   (let [files (r/atom #{})]
-    (controller/raise! :data/reset-bundle-add-messages nil)
+    (controller/raise! :collect/reset-bundle-add-messages nil)
     (fn []
       (let [{:keys [ba/pending?
                     ba/failure-message
-                    ba/success-message] :as bundle-add} (data/get-app-state :app/bundle-add)
-            datapack-id (utils/query-param :msid)]
+                    ba/success-message
+                    ba/data] :as bundle-add} (data/get-app-state :app/bundle-add)]
         [:div#create-datapack-view
          (shared/header :string/share-files-to-datapack nil #{:center})
          [:div.flex-center
-          (if datapack-id
+          (if data
             [:div.container.padded-content
              [editable-field nil
               [:div
-               (get-string :string/datapack-collect-intro-text)]]
+               [:h4
+                (get-string :string/datapack-collect-intro-text-1)]
+               [:h4
+                (get-string :string/datapack-collect-intro-text-2)]
+               [:ul
+                [:li (get-string :string/datapack-collect-intro-text-li-1)]
+                [:li (get-string :string/datapack-collect-intro-text-li-2)]]]]
              [show-files files {:disabled? (or pending?
                                                success-message)}]
              [:div
@@ -120,8 +126,7 @@
                                :disabled? (or pending?
                                               (empty? @files)
                                               success-message)}
-                              #(controller/raise! :data/add-collect-files-to-datapack {:added-files @files
-                                                                                       :datapack-id datapack-id}))
+                              #(controller/raise! :collect/add-files-to-datapack {:added-files @files}))
                (cond
                  success-message [:span.success success-message]
                  pending? [:span (get-string :string/sending "....")])]
@@ -134,6 +139,6 @@
                                     :prevent? true
                                     :disabled? false}
                                    #(route/navigate! :app/data-dash)))
-              (when failure-message [:div.error failure-message])]]
+              (when failure-message [:p.error failure-message])]]
             [:div.container.padded-content
-             [:span.error (get-string :string/datapack-no-id-supplied)]])]]))))
+             [:span.error (get-string :string/bundle-add-bad-data)]])]]))))

--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -900,20 +900,19 @@
                (when failure-message [:div.error failure-message])]))]]]))))
 
 (def tabs
-  [[0 :overview]
-   [1 :sharing]
-   [2 :edit]
-   [3 :files]
-   ;;[4 :collect]
-   ])
+  {:overview (get-string :string/overview)
+   :sharing (get-string :string/sharing)
+   :edit (get-string :string/edit)
+   :files (get-string :string/files)
+   :collect (get-string :string/collect)})
 
 (defn idx->tab
   [i]
-  (get (into {} tabs) i :overview))
+  (nth (keys tabs) i))
 
 (defn tab->idx
   [i]
-  (get (zipmap (map second tabs) (map first tabs)) i 0))
+  (get (zipmap (keys tabs) (range (count tabs))) i 0))
 
 (defn switch-primary-view!
   [k]
@@ -926,20 +925,12 @@
   (cond
     (= "stored" (:kixi.datastore.metadatastore/type md))
     (if has-edit?
-      {:overview (get-string :string/overview)
-       :sharing (get-string :string/sharing)
-       :edit (get-string :string/edit)}
-      {:overview (get-string :string/overview)
-       :sharing (get-string :string/sharing)})
+      (select-keys tabs [:overview :sharing :edit])
+      (select-keys tabs [:overview :sharing]))
     (= "datapack" (:kixi.datastore.metadatastore/bundle-type md))
     (if has-edit?
-      {:overview (get-string :string/overview)
-       :files (get-string :string/files)
-       ;;:collect (get-string :string/collect)
-       :sharing (get-string :string/sharing)
-       :edit (get-string :string/edit)}
-      {:overview (get-string :string/overview)
-       :sharing (get-string :string/sharing)})
+      (select-keys tabs [:overview :files :collect :sharing :edit])
+      (select-keys tabs [:overview :sharing]))
     :else {}))
 
 ;;

--- a/src/cljs/witan/ui/components/login.cljs
+++ b/src/cljs/witan/ui/components/login.cljs
@@ -223,6 +223,7 @@
                                                         :pass (.-value (. js/document (getElementById "login-password")))})
                         (.preventDefault e))}
     [:input {:tab-index 1
+             :auto-complete "username"
              :ref "email"
              :type "email"
              :id "login-email"
@@ -230,6 +231,7 @@
              :required :required}]
     [:input (merge password-validation
                    {:tab-index 2
+                    :auto-complete "current-password"
                     :ref "password"
                     :type "password"
                     :id "login-password"

--- a/src/cljs/witan/ui/controllers/collect.cljs
+++ b/src/cljs/witan/ui/controllers/collect.cljs
@@ -1,10 +1,14 @@
 (ns witan.ui.controllers.collect
   (:require [witan.ui.activities :as activities]
+            [witan.ui.route :as route]
             [witan.ui.data :as data]
             [witan.ui.ajax :as ajax]
             [witan.ui.strings :refer [get-string]]
+            [witan.ui.title :refer [set-title!]]
             [goog.string :as gstring])
   (:require-macros [cljs-log.core :as log]))
+
+(def bundle-add-page-data-query-param :d)
 
 (defn reset-messages
   []
@@ -14,6 +18,20 @@
 (defn reset-pending
   [b]
   (data/swap-app-state! :app/collect assoc :collect/pending? b))
+
+;; Bundle add to datapack via collect and share: message and pending components.
+(defn reset-bundle-add-messages
+  []
+  (data/swap-app-state! :app/bundle-add assoc :ba/failure-message nil)
+  (data/swap-app-state! :app/bundle-add assoc :ba/success-message nil))
+
+(defn reset-bundle-add-pending
+  [b]
+  (data/swap-app-state! :app/bundle-add assoc :ba/pending? b))
+
+(defn get-self-group
+  [{:keys [kixi.user/id]}]
+  )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -26,6 +44,11 @@
   (reset-messages))
 
 (defmethod handle
+  :reset-bundle-add-messages
+  [_ _]
+  (reset-bundle-add-messages))
+
+(defmethod handle
   :send-collect-request
   [event {:keys [groups message metadata]}]
   (reset-pending true)
@@ -35,8 +58,10 @@
    (data/new-command!
     :kixi.collect/request-collection
     "1.0.0"
-    {:kixi.collect/message message
-     :kixi.collect/groups (map :kixi.group/id groups)
+    {:kixi.collect.request/message message
+     :kixi.collect.request/submit-route (str "/#" (route/find-path :app/datapack-bundle-add) "?" (name bundle-add-page-data-query-param) "=")
+     :kixi.collect.request/requested-groups (set (map :kixi.group/id groups))
+     :kixi.collect.request/receiving-groups #{(:kixi.user/self-group (data/get-user))} ;; TODO allow user to select?
      :kixi.datastore.metadatastore/id (:kixi.datastore.metadatastore/id metadata)})
    {:failed #(gstring/format (get-string :string.activity.send-collect-request/failed)
                              (:kixi.datastore.metadatastore/name metadata))
@@ -45,6 +70,23 @@
                                 (:kixi.datastore.metadatastore/name metadata))
     :context {:groups groups
               :metadata metadata}}))
+
+(defmethod handle
+  :add-files-to-datapack
+  [event {:keys [added-files]}]
+  (reset-bundle-add-pending true)
+  (reset-bundle-add-messages)
+  (let [data (data/get-in-app-state :app/bundle-add :ba/data)
+        datapack-id (:kixi.datastore.metadatastore/id data)
+        bundled-ids (set (map :kixi.datastore.metadatastore/id added-files))]
+    (activities/start-activity!
+     :submit-to-collection
+     (data/new-command! :kixi.datastore/add-files-to-bundle "1.0.0"
+                        {:kixi.datastore.metadatastore/id datapack-id
+                         :kixi.datastore.metadatastore/bundled-ids bundled-ids})
+     {:failed #(get-string :string.activity.add-files-to-datapack/failed)
+      :completed #(get-string :string.activity.add-files-to-datapack/completed)
+      :context (assoc data :kixi.datastore.metadatastore/bundled-ids bundled-ids)})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -76,17 +118,80 @@
     (.error js/toastr (gstring/format (get-string :string.activity.send-collect-request/failed)
                                       (:kixi.datastore.metadatastore/name metadata)))))
 
+(defmethod on-activity-finished
+  [:submit-to-collection :completed]
+  [{:keys [args]}]
+  (reset-bundle-add-pending false)
+  (data/swap-app-state! :app/bundle-add assoc :ba/success-message
+                        (get-string :string.activity.add-files-to-datapack/completed))
+  (.info js/toastr (:log args)))
+
+(defmethod on-activity-finished
+  [:submit-to-collection :failed]
+  [{:keys [args]}]
+  (let [{:keys [message]} args]
+    (reset-bundle-add-pending false)
+    (data/swap-app-state! :app/bundle-add assoc :ba/failure-message
+                          (get-string :string.activity.add-files-to-datapack/failed " " (:kixi.event.metadata.sharing-change.rejection/reason message)))
+    (.error js/toastr (:log args))))
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defmulti on-activity-progressed
-  (fn [{:keys [args]}]  (get-in args [:activity :activity])))
+  (fn [{:keys [args]}] (get-in args [:activity :activity])))
 
 (defmethod on-activity-progressed
   :default [_])
 
+(defmethod on-activity-progressed
+  :submit-to-collection
+  [{args :args}]
+  (when (= 2 (get-in args [:activity :state :state-index]))
+    (let [{:keys [kixi.collect.request/receiving-groups
+                  :kixi.datastore.metadatastore/bundled-ids]} (get-in args [:activity :context])]
+      (data/new-command!
+       :kixi.datastore/sharing-change "2.0.0"
+       {:kixi.datastore.metadatastore/activity :kixi.datastore.metadatastore/meta-read
+        ;; TODO only do the FIRST group! This is a hack until this whole process is moved to kixi.collect!
+        :kixi.group/id (first receiving-groups)
+        :kixi.datastore.metadatastore/sharing-update :kixi.datastore.metadatastore/sharing-conj
+        ;; TODO only do the FIRST metadata ID! This is a hack until this whole process is moved to kixi.collect!
+        :kixi.datastore.metadatastore/id (first bundled-ids)})
+      (data/new-command!
+       :kixi.datastore/sharing-change "2.0.0"
+       {:kixi.datastore.metadatastore/activity :kixi.datastore.metadatastore/file-read
+        ;; TODO only do the FIRST group! This is a hack until this whole process is moved to kixi.collect!
+        :kixi.group/id (first receiving-groups)
+        :kixi.datastore.metadatastore/sharing-update :kixi.datastore.metadatastore/sharing-conj
+        ;; TODO only do the FIRST metadata ID! This is a hack until this whole process is moved to kixi.collect!
+        :kixi.datastore.metadatastore/id (first bundled-ids)}))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; On Route Change
+
+(defmulti on-route-change
+  (fn [{:keys [args]}] (:route/path args)))
+
+(defmethod on-route-change
+  :default [_])
+
+(defmethod on-route-change
+  :app/datapack-bundle-add
+  [_]
+  (set-title! (get-string :string/share-files-to-datapack))
+  (try
+    (let [data (-> bundle-add-page-data-query-param
+                   (route/get-query-param)
+                   (data/decode-string)
+                   (data/transit-decode))]
+      (log/debug "Collection data:" data)
+      (data/swap-app-state! :app/bundle-add assoc :ba/data data))
+    (catch js/Object e
+      (data/swap-app-state! :app/bundle-add assoc :ba/data nil))))
 
 (defonce subscriptions
   (do
+    (data/subscribe-topic :data/route-changed  on-route-change)
     (data/subscribe-topic :activity/activity-finished on-activity-finished)
     (data/subscribe-topic :activity/activity-progressed on-activity-progressed)))

--- a/src/cljs/witan/ui/data.cljs
+++ b/src/cljs/witan/ui/data.cljs
@@ -2,6 +2,7 @@
   (:require [reagent.core :as r]
             [goog.net.cookies :as cookies]
             [goog.crypt.base64 :as b64]
+            [clojure.string :as str]
             [schema.core :as s]
             [witan.ui.schema :as ws]
             [witan.ui.strings :refer [get-string]]
@@ -150,7 +151,8 @@
                   :collect/success-message nil}
     :app/bundle-add {:ba/pending? false
                      :ba/failure-message nil
-                     :ba/success-message nil}}
+                     :ba/success-message nil
+                     :ba/data nil}}
    (s/validate ws/AppStateSchema)
    (atomize-map)))
 
@@ -261,7 +263,11 @@
 
 (defn decode-string
   [s]
-  (.decodeURIComponent js/window (b64/decodeString s)))
+  ;; we sometimes use 'url-safe' b64: https://commons.apache.org/proper/commons-codec/apidocs/src-html/org/apache/commons/codec/binary/Base64.html#line.92
+  (let [r (-> s
+              (str/replace "-" "+")
+              (str/replace "_" "/"))]
+    (.decodeURIComponent js/window (b64/decodeString r))))
 
 (defn save-data!
   []

--- a/src/cljs/witan/ui/schema.cljs
+++ b/src/cljs/witan/ui/schema.cljs
@@ -72,6 +72,12 @@
                                                                             :else s/Keyword)}
                                              :else s/Keyword)]})
 
+(def BundleAddData
+  {:kixi.collect.request/receiving-groups #{uuid?}
+   :kixi.datastore.metadatastore/id uuid?
+   :kixi.collect.campaign/id uuid?
+   :kixi.collect.request/id uuid?})
+
 ;; app state schema
 (def AppStateSchema
   {:app/login {:login/pending? s/Bool
@@ -142,6 +148,7 @@
                  :collect/success-message (s/maybe s/Str)}
    :app/bundle-add {:ba/pending? s/Bool
                     :ba/failure-message (s/maybe s/Str)
-                    :ba/success-message (s/maybe s/Str)}
+                    :ba/success-message (s/maybe s/Str)
+                    :ba/data (s/maybe BundleAddData)}
    :app/activities {:activities/log [ActivityLogSchema]
                     :activities/pending {uuid? ActivityPendingSchema}}})

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -312,6 +312,7 @@
    :string/datapack-collect-intro-text-li-1 "They will be able to see the file and read the metadata assigned to the file."
    :string/datapack-collect-intro-text-li-2 "They will be able to download the file."
    :string/collect-bundle-add-return        "Click here to return to the dashboard."
+   :string/files-with-meta-edit-only        "You may only select files for which you have the 'Edit' permission."
    ;;
    :string.about/contact-us-1                "If you need Witan support, please either use our live help system or email us at"
    :string.about/contact-us-2                "For all other enquiries, please email us at"

--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -32,7 +32,7 @@
    :string/forecast-lastmodified            "Last Modified"
    :string/create-account-header            "Need an account?"
    :string/view                             "View"
-   :string/if-persists                      ["If the problem persists, please contact us at ":string/support-email]
+   :string/if-persists                      ["If the problem persists, please contact us at " :string/support-email]
    :string/api-failure                      ["Sorry, we're having a problem with the service. Please try again. If the problem persists, please contact us at " :string/support-email]
    :string/thanks                           "Thanks"
    :string/upload                           "Upload"
@@ -191,7 +191,7 @@
    :string/file-sharing-meta-read           "Read Metadata"
    :string/file-sharing-meta-update         "Edit Metadata"
    :string/file-sharing-file-read           "Download Dataset"
-   :string/datapack-sharing-bundle-add      "Add Files"
+   :string/datapack-sharing-bundle-add      "Add File"
    :string/datapack-bundle-add              "Share Files to a Datapack"
    :string/file-actions-download-file       "Download this dataset"
    :string/sharing-matrix-group-name        "Group Name"
@@ -269,8 +269,8 @@
    :string/create-datapack-search-files     "Search for files by their titles..."
    :string/edit-datapack-search-files       "Search for files to add to the datapack..."
    :string/create-datapack-no-files         "You have not yet added any files to the datapack. Use the search box to select the files you would like to add."
-   :string/datapack-no-id-supplied          "No datapack id was supplied."
-   :string/datapack-create-unknown-error    "Unexpected exception has occured, please contact support."
+   :string/bundle-add-bad-data              ["The link has expired or is malformed. Please contact us at " :string/support-email]
+   :string/datapack-create-unknown-error    ["Unexpected exception has occured. Please contact us at " :string/support-email]
    :string/na                               "n/a"
    :string/cancel                           "Cancel"
    :string/ok                               "OK"
@@ -305,9 +305,12 @@
    :string/collect-message-ph               "Provide a detailed message to the participants so they understand the kinds of files you'd like them to contribute."
    :string/collect-send-request             "Send Collect request"
    :string/collection-failed                "Failed to send Collect request: "
-   :stringf/collection-succeeded             "Collect request sent to %s recipient(s)!"
-   :string/share-files-to-datapack          "Add Files to Datapack"
-   :string/datapack-collect-intro-text      "You have been invited to add files to a datapack. Use the search bar to find the files and click on the title to add that file to the datapack. When you have selected all the files you want to add click on 'Add Files' to complete the request."
+   :stringf/collection-succeeded            "Collect request sent to %s recipient(s)!"
+   :string/share-files-to-datapack          "Add File to Datapack"
+   :string/datapack-collect-intro-text-1    ["You have been invited to add a file to a datapack. If you're unsure of the origin of this request then please either contact the original requester, or " :string/support-email ". Use the search bar to find the file you wish to add and click it. When you have selected the file you want to add, click on 'Add File' to complete the request."]
+   :string/datapack-collect-intro-text-2    "Please note that files added to a datapack in this manner will also grant additional permissions to the original requester:"
+   :string/datapack-collect-intro-text-li-1 "They will be able to see the file and read the metadata assigned to the file."
+   :string/datapack-collect-intro-text-li-2 "They will be able to download the file."
    :string/collect-bundle-add-return        "Click here to return to the dashboard."
    ;;
    :string.about/contact-us-1                "If you need Witan support, please either use our live help system or email us at"

--- a/src/styles/witan/ui/style/colour.clj
+++ b/src/styles/witan/ui/style/colour.clj
@@ -52,6 +52,7 @@
 (def subtle-grey "#dfe3e9")
 (def subtle-grey2 (color/darken subtle-grey 10))
 (def subtle-grey3 (color/darken subtle-grey 20))
+(def subtle-grey4 (color/darken subtle-grey 30))
 ;;
 (def error   color-complement-0)
 (def warning color-secondary-2-0)

--- a/src/styles/witan/ui/style/shared.clj
+++ b/src/styles/witan/ui/style/shared.clj
@@ -277,8 +277,9 @@
              [:.shared-tab
               {:margin [[(em 0.0) (em 0.75)]]
                :margin-top (em 0.8)
-               :color colour/subtle-grey3
-               :cursor :pointer}
+               :color colour/subtle-grey4
+               :cursor :pointer
+               :font-size (px 16)}
               [:&:hover
                {:color colour/clickable}]]
              [:.shared-tab-selected


### PR DESCRIPTION
**Add facilities required for collect and share v1**

* Collect tab is visible from the datapack page
* Collection requests can now be sent to one or more users
* The 'Bundle Add' page is now accessed from the `/app/datapack-add` route and requires a base64 query parameter payload
* The 'submit-to-collection' temporarily manages setting permissions