### PR TITLE
Clicking a tag now does a tag search

### DIFF
--- a/src/cljs/witan/ui/components/data.cljs
+++ b/src/cljs/witan/ui/components/data.cljs
@@ -239,7 +239,7 @@
     (if (zero? (count tags))
       [:i (get-string :string/no-tags)]
       (for [tag tags]
-        (shared/tag tag identity)))]])
+        (shared/tag tag)))]])
 
 (defn files
   [{:keys [kixi.datastore.metadatastore/bundled-files]} on-edit-fn]

--- a/src/cljs/witan/ui/components/shared.cljs
+++ b/src/cljs/witan/ui/components/shared.cljs
@@ -4,6 +4,7 @@
             ;;
             [witan.ui.data :as data]
             [witan.ui.utils :as utils]
+            [witan.ui.route :as route]
             [goog.string :as gstring]
             [witan.ui.controller :as controller]
             [witan.ui.strings :refer [get-string]]
@@ -421,13 +422,16 @@
 
 (defn tag
   ([tag-string]
-   (tag tag-string nil nil))
+   (tag tag-string
+        #(route/navigate! :app/data-dash {} {:search-term (str "tag(" % ")")})
+        nil))
   ([tag-string on-click-fn]
    (tag tag-string on-click-fn nil))
   ([tag-string on-click-fn on-cross-fn]
    [:div
     {:key (str "tag-" tag-string)
-     :class (str "shared-tag " (when on-click-fn "shared-tag-clickable"))}
+     :class (str "shared-tag " (when on-click-fn "shared-tag-clickable"))
+     :on-click #(when on-click-fn (on-click-fn tag-string))}
     (when on-cross-fn
       [:div.tag-close {:on-click #(on-cross-fn tag-string)}
        (icons/close)])

--- a/test/cljs/witan/ui/runner.cljs
+++ b/test/cljs/witan/ui/runner.cljs
@@ -8,6 +8,7 @@
            [witan.ui.test.data-test]
            [witan.ui.test.activities-test]
            [witan.ui.test.controllers.datastore-test]
+           [witan.ui.test.controllers.search-test]
            [witan.ui.test.components.create-datapack-test]
            [witan.ui.test.components.shared-test]
            ;;
@@ -27,5 +28,6 @@
            'witan.ui.test.data-test
            'witan.ui.test.activities-test
            'witan.ui.test.controllers.datastore-test
+           'witan.ui.test.controllers.search-test
            'witan.ui.test.components.create-datapack-test
            'witan.ui.test.components.shared-test)

--- a/test/cljs/witan/ui/test/controllers/search_test.cljs
+++ b/test/cljs/witan/ui/test/controllers/search_test.cljs
@@ -1,0 +1,16 @@
+(ns witan.ui.test.controllers.search-test
+  (:require  [cljs.test :refer-macros [deftest is testing async]]
+             [reagent.core :as r]
+             [witan.ui.test.base :as b]
+             [witan.ui.controllers.search :as search]
+             [cljs.core.async :refer [chan <! >! timeout pub sub unsub unsub-all put! close!]])
+  (:require-macros [cljs-log.core :as log]
+                   [cljs.core.async.macros :refer [go go-loop]]
+                   [witan.ui.env :as env :refer [cljs-env]]))
+
+(deftest extract-tags-from-search-term-test
+  (is (= [nil nil] (search/extract-tags-from-search-term nil)))
+  (is (= ["foo" nil] (search/extract-tags-from-search-term "foo")))
+  (is (= ["foo" #{"bar"}] (search/extract-tags-from-search-term "foo tag(bar)")))
+  (is (= ["foo baz" #{"bar" "qux"}] (search/extract-tags-from-search-term "foo tag(bar) baz tag(qux)")))
+  (is (= ["foo" #{"bar baz"}] (search/extract-tags-from-search-term "foo tag(bar baz)"))))


### PR DESCRIPTION
To perform a tag search we simply write "tag(my tag here)" into the search bar and it'll perform a tag search

Known issue: tags with spaces don't appear to return matches. This could be a kixi.search issue.