### PR TITLE
No longer toggle button disabled/enabled; instead report error

### DIFF
--- a/src/cljs/witan/ui/strings.cljs
+++ b/src/cljs/witan/ui/strings.cljs
@@ -318,6 +318,7 @@
    :string/files-with-meta-edit-only        "You may only select files for which you have the 'Edit' permission."
    :string/collect-data-from                "Collect data from"
    :string/share-data-with                  "Share it with"
+   :string/datapack-title-error             "The datapack title cannot be left blank"
    ;;
    :string.about/contact-us-1                "If you need Witan support, please either use our live help system or email us at"
    :string.about/contact-us-2                "For all other enquiries, please email us at"


### PR DESCRIPTION
**No longer toggle button disabled/enabled; instead report error**
This is because Ghost Inspector tests occasionally fail to have the
button enable properly. Instead just leave it enabled but show an
error message if everything isn't filled in properly